### PR TITLE
Refactor deep-linking to use coordinates instead of detection names

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,7 @@ refresh:
 		-Z10 -z14 -r1 -pk -pf $(GEOJSON)
 	tile-join -o $(PMTILES) --force $(DATA_DIR)/low.pmtiles $(DATA_DIR)/high.pmtiles
 	rm -f $(DATA_DIR)/low.pmtiles $(DATA_DIR)/high.pmtiles
-	gcloud storage cp $(PMTILES) $(GCS_BUCKET)/
 	@echo "Refreshed: $$(duckdb -noheader -list $(DB) 'SELECT COUNT(*) FROM detections') detections"
-	@echo "Deployed to: https://storage.googleapis.com/burnoff-data/detections.pmtiles"
 
 # Sync terminals from research repo
 $(DATA_DIR)/terminals.json: | $(DATA_DIR)

--- a/data/detections.json
+++ b/data/detections.json
@@ -1065,6 +1065,1446 @@
     "type": "Import"
   },
   {
+    "lat": 29.745861,
+    "lon": -93.869248,
+    "start_date": "2025-01-01",
+    "end_date": "2025-12-31",
+    "images": 78,
+    "detections": 36,
+    "detection_rate": 0.46153846153846156,
+    "max_b12": 1.4096999168395996,
+    "detection_dates": [
+      {
+        "date": "2025-01-07",
+        "max_b12": 1.403999924659729,
+        "pixels": 2,
+        "flare_lon": -93.872951261591,
+        "flare_lat": 29.75366248317997,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/1/S2B_15RVP_20250107_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/1/S2B_15RVP_20250107_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/1/S2B_15RVP_20250107_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-01-07",
+        "max_b12": 1.2034999132156372,
+        "pixels": 1,
+        "flare_lon": -93.87506916754792,
+        "flare_lat": 29.760284601647662,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2B_15RVN_20250107_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2B_15RVN_20250107_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2B_15RVN_20250107_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-01-07",
+        "max_b12": 0.9886999130249023,
+        "pixels": 1,
+        "flare_lon": -93.87301358917834,
+        "flare_lat": 29.760853396778252,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2B_15RVN_20250107_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2B_15RVN_20250107_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2B_15RVN_20250107_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-01-07",
+        "max_b12": 1.1734999418258667,
+        "pixels": 1,
+        "flare_lon": -93.87537508745952,
+        "flare_lat": 29.753646468108446,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/1/S2B_15RVP_20250107_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/1/S2B_15RVP_20250107_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/1/S2B_15RVP_20250107_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-01-22",
+        "max_b12": 0.9777998924255371,
+        "pixels": 1,
+        "flare_lon": -93.87506916754792,
+        "flare_lat": 29.760284601647662,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2C_15RVN_20250122_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2C_15RVN_20250122_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2C_15RVN_20250122_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-01-22",
+        "max_b12": 0.9269999265670776,
+        "pixels": 2,
+        "flare_lon": -93.87506916754792,
+        "flare_lat": 29.760284601647662,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2C_15RVN_20250122_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2C_15RVN_20250122_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2C_15RVN_20250122_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-01-22",
+        "max_b12": 1.4047999382019043,
+        "pixels": 1,
+        "flare_lon": -93.87301358917834,
+        "flare_lat": 29.760853396778252,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2C_15RVN_20250122_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2C_15RVN_20250122_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2C_15RVN_20250122_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-02-01",
+        "max_b12": 1.4047999382019043,
+        "pixels": 2,
+        "flare_lon": -93.87438352813862,
+        "flare_lat": 29.751114909045608,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/2/S2C_15RVP_20250201_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/2/S2C_15RVP_20250201_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/2/S2C_15RVP_20250201_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-02-01",
+        "max_b12": 0.9210999011993408,
+        "pixels": 1,
+        "flare_lon": -93.87506916754792,
+        "flare_lat": 29.760284601647662,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2C_15RVN_20250201_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2C_15RVN_20250201_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2C_15RVN_20250201_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-02-01",
+        "max_b12": 1.1286998987197876,
+        "pixels": 2,
+        "flare_lon": -93.87506916754792,
+        "flare_lat": 29.760284601647662,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2C_15RVN_20250201_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2C_15RVN_20250201_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2C_15RVN_20250201_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-02-06",
+        "max_b12": 0.8691999316215515,
+        "pixels": 1,
+        "flare_lon": -93.87506916754792,
+        "flare_lat": 29.760284601647662,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250206_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250206_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250206_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-02-06",
+        "max_b12": 0.9302999973297119,
+        "pixels": 2,
+        "flare_lon": -93.87506916754792,
+        "flare_lat": 29.760284601647662,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250206_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250206_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250206_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-02-06",
+        "max_b12": 1.4096999168395996,
+        "pixels": 1,
+        "flare_lon": -93.87301358917834,
+        "flare_lat": 29.760853396778252,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250206_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250206_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250206_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-02-16",
+        "max_b12": 1.407099962234497,
+        "pixels": 2,
+        "flare_lon": -93.872951261591,
+        "flare_lat": 29.75366248317997,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/2/S2B_15RVP_20250216_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/2/S2B_15RVP_20250216_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/2/S2B_15RVP_20250216_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-02-16",
+        "max_b12": 1.1164000034332275,
+        "pixels": 1,
+        "flare_lon": -93.87438352813862,
+        "flare_lat": 29.751114909045608,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/2/S2B_15RVP_20250216_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/2/S2B_15RVP_20250216_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/2/S2B_15RVP_20250216_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-02-16",
+        "max_b12": 1.340999960899353,
+        "pixels": 1,
+        "flare_lon": -93.87506916754792,
+        "flare_lat": 29.760284601647662,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250216_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250216_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250216_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-02-16",
+        "max_b12": 1.2596999406814575,
+        "pixels": 1,
+        "flare_lon": -93.87301358917834,
+        "flare_lat": 29.760853396778252,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250216_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250216_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250216_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-02-16",
+        "max_b12": 1.3635998964309692,
+        "pixels": 1,
+        "flare_lon": -93.87537508745952,
+        "flare_lat": 29.753646468108446,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/2/S2B_15RVP_20250216_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/2/S2B_15RVP_20250216_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/2/S2B_15RVP_20250216_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-02-26",
+        "max_b12": 1.2959998846054077,
+        "pixels": 2,
+        "flare_lon": -93.87506916754792,
+        "flare_lat": 29.760284601647662,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250226_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250226_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250226_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-02-26",
+        "max_b12": 1.402999997138977,
+        "pixels": 2,
+        "flare_lon": -93.87301358917834,
+        "flare_lat": 29.760853396778252,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250226_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250226_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250226_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-03-03",
+        "max_b12": 0.8757999539375305,
+        "pixels": 1,
+        "flare_lon": -93.87506916754792,
+        "flare_lat": 29.760284601647662,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/3/S2C_15RVN_20250303_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/3/S2C_15RVN_20250303_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/3/S2C_15RVN_20250303_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-03-03",
+        "max_b12": 1.0221999883651733,
+        "pixels": 1,
+        "flare_lon": -93.87301358917834,
+        "flare_lat": 29.760853396778252,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/3/S2C_15RVN_20250303_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/3/S2C_15RVN_20250303_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/3/S2C_15RVN_20250303_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-04-12",
+        "max_b12": 0.872499942779541,
+        "pixels": 1,
+        "flare_lon": -93.872951261591,
+        "flare_lat": 29.75366248317997,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/4/S2C_15RVP_20250412_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/4/S2C_15RVP_20250412_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/4/S2C_15RVP_20250412_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-04-12",
+        "max_b12": 1.1483999490737915,
+        "pixels": 1,
+        "flare_lon": -93.87438352813862,
+        "flare_lat": 29.751114909045608,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/4/S2C_15RVP_20250412_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/4/S2C_15RVP_20250412_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/4/S2C_15RVP_20250412_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-04-12",
+        "max_b12": 1.0153999328613281,
+        "pixels": 2,
+        "flare_lon": -93.87506916754792,
+        "flare_lat": 29.760284601647662,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/4/S2C_15RVN_20250412_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/4/S2C_15RVN_20250412_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/4/S2C_15RVN_20250412_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-04-12",
+        "max_b12": 1.034500002861023,
+        "pixels": 1,
+        "flare_lon": -93.87301358917834,
+        "flare_lat": 29.760853396778252,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/4/S2C_15RVN_20250412_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/4/S2C_15RVN_20250412_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/4/S2C_15RVN_20250412_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-04-12",
+        "max_b12": 0.8695999383926392,
+        "pixels": 2,
+        "flare_lon": -93.87537508745952,
+        "flare_lat": 29.753646468108446,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/4/S2C_15RVP_20250412_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/4/S2C_15RVP_20250412_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/4/S2C_15RVP_20250412_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-05-04",
+        "max_b12": 1.244499921798706,
+        "pixels": 1,
+        "flare_lon": -93.87438352813862,
+        "flare_lat": 29.751114909045608,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/5/S2A_15RVP_20250504_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/5/S2A_15RVP_20250504_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/5/S2A_15RVP_20250504_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-05-04",
+        "max_b12": 1.0471999645233154,
+        "pixels": 1,
+        "flare_lon": -93.87506916754792,
+        "flare_lat": 29.760284601647662,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/5/S2A_15RVN_20250504_1_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/5/S2A_15RVN_20250504_1_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/5/S2A_15RVN_20250504_1_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-05-04",
+        "max_b12": 0.9101999998092651,
+        "pixels": 1,
+        "flare_lon": -93.87537508745952,
+        "flare_lat": 29.753646468108446,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/5/S2A_15RVP_20250504_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/5/S2A_15RVP_20250504_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/5/S2A_15RVP_20250504_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-07-21",
+        "max_b12": 1.3431999683380127,
+        "pixels": 1,
+        "flare_lon": -93.87438352813862,
+        "flare_lat": 29.751114909045608,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/7/S2C_15RVP_20250721_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/7/S2C_15RVP_20250721_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/7/S2C_15RVP_20250721_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-07-21",
+        "max_b12": 0.8534999489784241,
+        "pixels": 1,
+        "flare_lon": -93.87506916754792,
+        "flare_lat": 29.760284601647662,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/7/S2C_15RVN_20250721_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/7/S2C_15RVN_20250721_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/7/S2C_15RVN_20250721_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-08-15",
+        "max_b12": 0.9134999513626099,
+        "pixels": 1,
+        "flare_lon": -93.872951261591,
+        "flare_lat": 29.75366248317997,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2B_15RVP_20250815_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2B_15RVP_20250815_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2B_15RVP_20250815_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-08-15",
+        "max_b12": 1.3769999742507935,
+        "pixels": 2,
+        "flare_lon": -93.87438352813862,
+        "flare_lat": 29.751114909045608,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2B_15RVP_20250815_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2B_15RVP_20250815_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2B_15RVP_20250815_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-08-15",
+        "max_b12": 0.8303999304771423,
+        "pixels": 2,
+        "flare_lon": -93.87506916754792,
+        "flare_lat": 29.760284601647662,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/8/S2B_15RVN_20250815_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/8/S2B_15RVN_20250815_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/8/S2B_15RVN_20250815_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-08-15",
+        "max_b12": 0.828999936580658,
+        "pixels": 1,
+        "flare_lon": -93.87301358917834,
+        "flare_lat": 29.760853396778252,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/8/S2B_15RVN_20250815_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/8/S2B_15RVN_20250815_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/8/S2B_15RVN_20250815_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-08-15",
+        "max_b12": 0.9833999872207642,
+        "pixels": 1,
+        "flare_lon": -93.87543758805108,
+        "flare_lat": 29.760837377064448,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/8/S2B_15RVN_20250815_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/8/S2B_15RVN_20250815_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/8/S2B_15RVN_20250815_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-08-20",
+        "max_b12": 0.8064999580383301,
+        "pixels": 1,
+        "flare_lon": -93.872951261591,
+        "flare_lat": 29.75366248317997,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2C_15RVP_20250820_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2C_15RVP_20250820_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2C_15RVP_20250820_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-08-20",
+        "max_b12": 1.0191999673843384,
+        "pixels": 2,
+        "flare_lon": -93.87438352813862,
+        "flare_lat": 29.751114909045608,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2C_15RVP_20250820_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2C_15RVP_20250820_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2C_15RVP_20250820_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-08-20",
+        "max_b12": 0.8221999406814575,
+        "pixels": 1,
+        "flare_lon": -93.87537508745952,
+        "flare_lat": 29.753646468108446,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2C_15RVP_20250820_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2C_15RVP_20250820_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2C_15RVP_20250820_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-08-25",
+        "max_b12": 1.0571999549865723,
+        "pixels": 1,
+        "flare_lon": -93.87438352813862,
+        "flare_lat": 29.751114909045608,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2B_15RVP_20250825_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2B_15RVP_20250825_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2B_15RVP_20250825_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-09-04",
+        "max_b12": 0.9098999500274658,
+        "pixels": 1,
+        "flare_lon": -93.87438352813862,
+        "flare_lat": 29.751114909045608,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/9/S2B_15RVP_20250904_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/9/S2B_15RVP_20250904_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/9/S2B_15RVP_20250904_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-09-29",
+        "max_b12": 1.2009999752044678,
+        "pixels": 1,
+        "flare_lon": -93.87438352813862,
+        "flare_lat": 29.751114909045608,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/9/S2C_15RVP_20250929_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/9/S2C_15RVP_20250929_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/9/S2C_15RVP_20250929_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-10-04",
+        "max_b12": 1.0440999269485474,
+        "pixels": 1,
+        "flare_lon": -93.87438352813862,
+        "flare_lat": 29.751114909045608,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2B_15RVP_20251004_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2B_15RVP_20251004_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2B_15RVP_20251004_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-10-09",
+        "max_b12": 0.9926999807357788,
+        "pixels": 1,
+        "flare_lon": -93.87438352813862,
+        "flare_lat": 29.751114909045608,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2C_15RVP_20251009_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2C_15RVP_20251009_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2C_15RVP_20251009_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-10-09",
+        "max_b12": 0.997499942779541,
+        "pixels": 1,
+        "flare_lon": -93.87543758805108,
+        "flare_lat": 29.760837377064448,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/10/S2C_15RVN_20251009_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/10/S2C_15RVN_20251009_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/10/S2C_15RVN_20251009_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-10-11",
+        "max_b12": 1.3749998807907104,
+        "pixels": 1,
+        "flare_lon": -93.87438352813862,
+        "flare_lat": 29.751114909045608,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2A_15RVP_20251011_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2A_15RVP_20251011_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2A_15RVP_20251011_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-10-14",
+        "max_b12": 1.0221999883651733,
+        "pixels": 2,
+        "flare_lon": -93.87438352813862,
+        "flare_lat": 29.751114909045608,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2B_15RVP_20251014_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2B_15RVP_20251014_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2B_15RVP_20251014_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-10-14",
+        "max_b12": 0.9045999050140381,
+        "pixels": 2,
+        "flare_lon": -93.87506916754792,
+        "flare_lat": 29.760284601647662,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/10/S2B_15RVN_20251014_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/10/S2B_15RVN_20251014_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/10/S2B_15RVN_20251014_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-10-31",
+        "max_b12": 1.0399999618530273,
+        "pixels": 2,
+        "flare_lon": -93.87438352813862,
+        "flare_lat": 29.751114909045608,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2A_15RVP_20251031_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2A_15RVP_20251031_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2A_15RVP_20251031_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-11-03",
+        "max_b12": 1.4043999910354614,
+        "pixels": 4,
+        "flare_lon": -93.872951261591,
+        "flare_lat": 29.75366248317997,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/11/S2B_15RVP_20251103_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/11/S2B_15RVP_20251103_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/11/S2B_15RVP_20251103_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-11-03",
+        "max_b12": 1.4020999670028687,
+        "pixels": 2,
+        "flare_lon": -93.87301358917834,
+        "flare_lat": 29.760853396778252,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/11/S2B_15RVN_20251103_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/11/S2B_15RVN_20251103_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/11/S2B_15RVN_20251103_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-11-13",
+        "max_b12": 0.8092999458312988,
+        "pixels": 2,
+        "flare_lon": -93.87506916754792,
+        "flare_lat": 29.760284601647662,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/11/S2B_15RVN_20251113_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/11/S2B_15RVN_20251113_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/11/S2B_15RVN_20251113_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-11-20",
+        "max_b12": 1.0305999517440796,
+        "pixels": 1,
+        "flare_lon": -93.87301358917834,
+        "flare_lat": 29.760853396778252,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/11/S2A_15RVN_20251120_1_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/11/S2A_15RVN_20251120_1_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/11/S2A_15RVN_20251120_1_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-11-23",
+        "max_b12": 1.2381999492645264,
+        "pixels": 2,
+        "flare_lon": -93.87438352813862,
+        "flare_lat": 29.751114909045608,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/11/S2B_15RVP_20251123_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/11/S2B_15RVP_20251123_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/11/S2B_15RVP_20251123_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-12-10",
+        "max_b12": 0.8103999495506287,
+        "pixels": 1,
+        "flare_lon": -93.872951261591,
+        "flare_lat": 29.75366248317997,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/12/S2A_15RVP_20251210_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/12/S2A_15RVP_20251210_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/12/S2A_15RVP_20251210_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-12-30",
+        "max_b12": 1.0381999015808105,
+        "pixels": 1,
+        "flare_lon": -93.87438352813862,
+        "flare_lat": 29.751114909045608,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/12/S2A_15RVP_20251230_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/12/S2A_15RVP_20251230_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/12/S2A_15RVP_20251230_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.90002875033868,
+          29.718581994019164,
+          -93.83845058560202,
+          29.773133066966544
+        ],
+        "utm_bounds": [
+          412948.6022108068,
+          3287941.5896290876,
+          418948.6022108068,
+          3293941.5896290876
+        ],
+        "epsg": 32615
+      }
+    ],
+    "id": 3527,
+    "name": "Sabine Pass LNG Terminal (Regasification)",
+    "type": "Import"
+  },
+  {
     "lat": -12.522311,
     "lon": 130.86631,
     "start_date": "2025-01-01",
@@ -12746,6 +14186,1396 @@
     ],
     "id": 3586,
     "name": "Ichthys Plant (Darwin)",
+    "type": "Export"
+  },
+  {
+    "lat": 29.753249,
+    "lon": -93.872727,
+    "start_date": "2025-01-01",
+    "end_date": "2025-12-31",
+    "images": 78,
+    "detections": 33,
+    "detection_rate": 0.4230769230769231,
+    "max_b12": 1.4097999334335327,
+    "detection_dates": [
+      {
+        "date": "2025-01-07",
+        "max_b12": 0.9886999130249023,
+        "pixels": 2,
+        "flare_lon": -93.87303721012782,
+        "flare_lat": 29.761072806968286,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2B_15RVN_20250107_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2B_15RVN_20250107_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2B_15RVN_20250107_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-01-07",
+        "max_b12": 1.0633999109268188,
+        "pixels": 2,
+        "flare_lon": -93.87298221204973,
+        "flare_lat": 29.754727883867858,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/1/S2B_15RVP_20250107_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/1/S2B_15RVP_20250107_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/1/S2B_15RVP_20250107_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-01-07",
+        "max_b12": 1.2034999132156372,
+        "pixels": 1,
+        "flare_lon": -93.87546121426621,
+        "flare_lat": 29.761056786714885,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2B_15RVN_20250107_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2B_15RVN_20250107_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2B_15RVN_20250107_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-01-07",
+        "max_b12": 0.9485999345779419,
+        "pixels": 3,
+        "flare_lon": -93.87540900446606,
+        "flare_lat": 29.75505026354484,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/1/S2B_15RVP_20250107_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/1/S2B_15RVP_20250107_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/1/S2B_15RVP_20250107_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-01-22",
+        "max_b12": 1.4047999382019043,
+        "pixels": 1,
+        "flare_lon": -93.87303721012782,
+        "flare_lat": 29.761072806968286,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2C_15RVN_20250122_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2C_15RVN_20250122_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2C_15RVN_20250122_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-01-22",
+        "max_b12": 0.9777998924255371,
+        "pixels": 1,
+        "flare_lon": -93.87546121426621,
+        "flare_lat": 29.761056786714885,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2C_15RVN_20250122_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2C_15RVN_20250122_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2C_15RVN_20250122_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-01-22",
+        "max_b12": 0.9269999265670776,
+        "pixels": 1,
+        "flare_lon": -93.87447692054457,
+        "flare_lat": 29.75937122191132,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2C_15RVN_20250122_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2C_15RVN_20250122_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/1/S2C_15RVN_20250122_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-02-01",
+        "max_b12": 1.36899995803833,
+        "pixels": 2,
+        "flare_lon": -93.87441816386351,
+        "flare_lat": 29.752603304579175,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/2/S2C_15RVP_20250201_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/2/S2C_15RVP_20250201_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/2/S2C_15RVP_20250201_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-02-01",
+        "max_b12": 0.9210999011993408,
+        "pixels": 1,
+        "flare_lon": -93.87546121426621,
+        "flare_lat": 29.761056786714885,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2C_15RVN_20250201_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2C_15RVN_20250201_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2C_15RVN_20250201_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-02-01",
+        "max_b12": 0.8854999542236328,
+        "pixels": 1,
+        "flare_lon": -93.87447692054457,
+        "flare_lat": 29.75937122191132,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2C_15RVN_20250201_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2C_15RVN_20250201_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2C_15RVN_20250201_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-02-06",
+        "max_b12": 1.4096999168395996,
+        "pixels": 1,
+        "flare_lon": -93.87303721012782,
+        "flare_lat": 29.761072806968286,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250206_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250206_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250206_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-02-06",
+        "max_b12": 0.8691999316215515,
+        "pixels": 1,
+        "flare_lon": -93.87546121426621,
+        "flare_lat": 29.761056786714885,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250206_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250206_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250206_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-02-06",
+        "max_b12": 0.9302999973297119,
+        "pixels": 1,
+        "flare_lon": -93.87447692054457,
+        "flare_lat": 29.75937122191132,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250206_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250206_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250206_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-02-16",
+        "max_b12": 0.8753999471664429,
+        "pixels": 1,
+        "flare_lon": -93.87441816386351,
+        "flare_lat": 29.752603304579175,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/2/S2B_15RVP_20250216_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/2/S2B_15RVP_20250216_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/2/S2B_15RVP_20250216_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-02-16",
+        "max_b12": 1.2596999406814575,
+        "pixels": 2,
+        "flare_lon": -93.87303721012782,
+        "flare_lat": 29.761072806968286,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250216_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250216_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250216_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-02-16",
+        "max_b12": 1.1053999662399292,
+        "pixels": 3,
+        "flare_lon": -93.87298221204973,
+        "flare_lat": 29.754727883867858,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/2/S2B_15RVP_20250216_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/2/S2B_15RVP_20250216_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/2/S2B_15RVP_20250216_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-02-16",
+        "max_b12": 1.340999960899353,
+        "pixels": 1,
+        "flare_lon": -93.87546121426621,
+        "flare_lat": 29.761056786714885,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250216_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250216_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250216_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-02-16",
+        "max_b12": 0.9101999998092651,
+        "pixels": 3,
+        "flare_lon": -93.87540900446606,
+        "flare_lat": 29.75505026354484,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/2/S2B_15RVP_20250216_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/2/S2B_15RVP_20250216_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/2/S2B_15RVP_20250216_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-02-26",
+        "max_b12": 1.402999997138977,
+        "pixels": 3,
+        "flare_lon": -93.87303721012782,
+        "flare_lat": 29.761072806968286,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250226_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250226_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250226_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-02-26",
+        "max_b12": 1.2959998846054077,
+        "pixels": 2,
+        "flare_lon": -93.87546121426621,
+        "flare_lat": 29.761056786714885,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250226_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250226_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/2/S2B_15RVN_20250226_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-04-12",
+        "max_b12": 0.840999960899353,
+        "pixels": 1,
+        "flare_lon": -93.87441816386351,
+        "flare_lat": 29.752603304579175,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/4/S2C_15RVP_20250412_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/4/S2C_15RVP_20250412_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/4/S2C_15RVP_20250412_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-04-12",
+        "max_b12": 1.034500002861023,
+        "pixels": 1,
+        "flare_lon": -93.87303721012782,
+        "flare_lat": 29.761072806968286,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/4/S2C_15RVN_20250412_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/4/S2C_15RVN_20250412_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/4/S2C_15RVN_20250412_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-04-12",
+        "max_b12": 1.0153999328613281,
+        "pixels": 2,
+        "flare_lon": -93.87546121426621,
+        "flare_lat": 29.761056786714885,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/4/S2C_15RVN_20250412_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/4/S2C_15RVN_20250412_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/4/S2C_15RVN_20250412_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-04-12",
+        "max_b12": 1.0208998918533325,
+        "pixels": 3,
+        "flare_lon": -93.87540900446606,
+        "flare_lat": 29.75505026354484,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/4/S2C_15RVP_20250412_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/4/S2C_15RVP_20250412_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/4/S2C_15RVP_20250412_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-05-04",
+        "max_b12": 0.9492999315261841,
+        "pixels": 1,
+        "flare_lon": -93.87441816386351,
+        "flare_lat": 29.752603304579175,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/5/S2A_15RVP_20250504_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/5/S2A_15RVP_20250504_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/5/S2A_15RVP_20250504_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-05-04",
+        "max_b12": 1.0471999645233154,
+        "pixels": 1,
+        "flare_lon": -93.87546121426621,
+        "flare_lat": 29.761056786714885,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/5/S2A_15RVN_20250504_1_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/5/S2A_15RVN_20250504_1_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/5/S2A_15RVN_20250504_1_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-05-04",
+        "max_b12": 0.8399999737739563,
+        "pixels": 3,
+        "flare_lon": -93.87540900446606,
+        "flare_lat": 29.75505026354484,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/5/S2A_15RVP_20250504_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/5/S2A_15RVP_20250504_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/5/S2A_15RVP_20250504_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-07-21",
+        "max_b12": 0.921299934387207,
+        "pixels": 1,
+        "flare_lon": -93.87441816386351,
+        "flare_lat": 29.752603304579175,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/7/S2C_15RVP_20250721_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/7/S2C_15RVP_20250721_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/7/S2C_15RVP_20250721_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-08-15",
+        "max_b12": 1.1227999925613403,
+        "pixels": 1,
+        "flare_lon": -93.87441816386351,
+        "flare_lat": 29.752603304579175,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2B_15RVP_20250815_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2B_15RVP_20250815_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2B_15RVP_20250815_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-08-15",
+        "max_b12": 0.828999936580658,
+        "pixels": 1,
+        "flare_lon": -93.87303721012782,
+        "flare_lat": 29.761072806968286,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/8/S2B_15RVN_20250815_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/8/S2B_15RVN_20250815_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/8/S2B_15RVN_20250815_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-08-15",
+        "max_b12": 0.9833999872207642,
+        "pixels": 1,
+        "flare_lon": -93.87546121426621,
+        "flare_lat": 29.761056786714885,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/8/S2B_15RVN_20250815_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/8/S2B_15RVN_20250815_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/8/S2B_15RVN_20250815_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-08-15",
+        "max_b12": 0.8303999304771423,
+        "pixels": 1,
+        "flare_lon": -93.87447692054457,
+        "flare_lat": 29.75937122191132,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/8/S2B_15RVN_20250815_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/8/S2B_15RVN_20250815_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/8/S2B_15RVN_20250815_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-08-15",
+        "max_b12": 0.8763999342918396,
+        "pixels": 3,
+        "flare_lon": -93.87540900446606,
+        "flare_lat": 29.75505026354484,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2B_15RVP_20250815_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2B_15RVP_20250815_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2B_15RVP_20250815_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-08-20",
+        "max_b12": 0.9109998941421509,
+        "pixels": 1,
+        "flare_lon": -93.87441816386351,
+        "flare_lat": 29.752603304579175,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2C_15RVP_20250820_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2C_15RVP_20250820_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/8/S2C_15RVP_20250820_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-09-04",
+        "max_b12": 0.8365999460220337,
+        "pixels": 1,
+        "flare_lon": -93.87441816386351,
+        "flare_lat": 29.752603304579175,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/9/S2B_15RVP_20250904_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/9/S2B_15RVP_20250904_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/9/S2B_15RVP_20250904_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-09-09",
+        "max_b12": 0.9537999629974365,
+        "pixels": 1,
+        "flare_lon": -93.87441816386351,
+        "flare_lat": 29.752603304579175,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/9/S2C_15RVP_20250909_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/9/S2C_15RVP_20250909_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/9/S2C_15RVP_20250909_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-09-29",
+        "max_b12": 0.802299976348877,
+        "pixels": 1,
+        "flare_lon": -93.87441816386351,
+        "flare_lat": 29.752603304579175,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/9/S2C_15RVP_20250929_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/9/S2C_15RVP_20250929_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/9/S2C_15RVP_20250929_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-10-04",
+        "max_b12": 0.9477999210357666,
+        "pixels": 1,
+        "flare_lon": -93.87441816386351,
+        "flare_lat": 29.752603304579175,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2B_15RVP_20251004_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2B_15RVP_20251004_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2B_15RVP_20251004_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-10-09",
+        "max_b12": 0.8845999240875244,
+        "pixels": 1,
+        "flare_lon": -93.87441816386351,
+        "flare_lat": 29.752603304579175,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2C_15RVP_20251009_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2C_15RVP_20251009_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2C_15RVP_20251009_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-10-09",
+        "max_b12": 0.997499942779541,
+        "pixels": 1,
+        "flare_lon": -93.87546121426621,
+        "flare_lat": 29.761056786714885,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/10/S2C_15RVN_20251009_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/10/S2C_15RVN_20251009_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/10/S2C_15RVN_20251009_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-10-11",
+        "max_b12": 1.007099986076355,
+        "pixels": 1,
+        "flare_lon": -93.87441816386351,
+        "flare_lat": 29.752603304579175,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2A_15RVP_20251011_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2A_15RVP_20251011_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2A_15RVP_20251011_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-10-14",
+        "max_b12": 1.001099944114685,
+        "pixels": 2,
+        "flare_lon": -93.87441816386351,
+        "flare_lat": 29.752603304579175,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2B_15RVP_20251014_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2B_15RVP_20251014_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2B_15RVP_20251014_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-10-31",
+        "max_b12": 0.9362999200820923,
+        "pixels": 1,
+        "flare_lon": -93.87441816386351,
+        "flare_lat": 29.752603304579175,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2A_15RVP_20251031_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2A_15RVP_20251031_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/10/S2A_15RVP_20251031_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-11-03",
+        "max_b12": 1.4020999670028687,
+        "pixels": 3,
+        "flare_lon": -93.87303721012782,
+        "flare_lat": 29.761072806968286,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/11/S2B_15RVN_20251103_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/11/S2B_15RVN_20251103_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/11/S2B_15RVN_20251103_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-11-03",
+        "max_b12": 1.2253999710083008,
+        "pixels": 3,
+        "flare_lon": -93.87298221204973,
+        "flare_lat": 29.754727883867858,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/11/S2B_15RVP_20251103_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/11/S2B_15RVP_20251103_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/11/S2B_15RVP_20251103_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-11-20",
+        "max_b12": 1.0305999517440796,
+        "pixels": 1,
+        "flare_lon": -93.87303721012782,
+        "flare_lat": 29.761072806968286,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/11/S2A_15RVN_20251120_1_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/11/S2A_15RVN_20251120_1_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/11/S2A_15RVN_20251120_1_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-11-23",
+        "max_b12": 1.0055999755859375,
+        "pixels": 1,
+        "flare_lon": -93.87441816386351,
+        "flare_lat": 29.752603304579175,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/11/S2B_15RVP_20251123_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/11/S2B_15RVP_20251123_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/11/S2B_15RVP_20251123_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-11-23",
+        "max_b12": 1.4097999334335327,
+        "pixels": 4,
+        "flare_lon": -93.84386438730573,
+        "flare_lat": 29.78008651213844,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/11/S2B_15RVN_20251123_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/11/S2B_15RVN_20251123_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/11/S2B_15RVN_20251123_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-11-23",
+        "max_b12": 1.4047999382019043,
+        "pixels": 8,
+        "flare_lon": -93.84386438730573,
+        "flare_lat": 29.78008651213844,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/11/S2B_15RVP_20251123_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/11/S2B_15RVP_20251123_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/11/S2B_15RVP_20251123_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-11-23",
+        "max_b12": 1.3990999460220337,
+        "pixels": 6,
+        "flare_lon": -93.8438369016273,
+        "flare_lat": 29.77680828462004,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/11/S2B_15RVN_20251123_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/11/S2B_15RVN_20251123_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/11/S2B_15RVN_20251123_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-11-23",
+        "max_b12": 1.4097999334335327,
+        "pixels": 5,
+        "flare_lon": -93.8438369016273,
+        "flare_lat": 29.77680828462004,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/11/S2B_15RVN_20251123_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/11/S2B_15RVN_20251123_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VN/2025/11/S2B_15RVN_20251123_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-11-23",
+        "max_b12": 1.4047999382019043,
+        "pixels": 7,
+        "flare_lon": -93.8438369016273,
+        "flare_lat": 29.77680828462004,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/11/S2B_15RVP_20251123_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/11/S2B_15RVP_20251123_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/11/S2B_15RVP_20251123_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-11-23",
+        "max_b12": 1.4047999382019043,
+        "pixels": 5,
+        "flare_lon": -93.8438369016273,
+        "flare_lat": 29.77680828462004,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/11/S2B_15RVP_20251123_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/11/S2B_15RVP_20251123_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/11/S2B_15RVP_20251123_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-11-28",
+        "max_b12": 1.156599998474121,
+        "pixels": 1,
+        "flare_lon": -93.87441816386351,
+        "flare_lat": 29.752603304579175,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/11/S2C_15RVP_20251128_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/11/S2C_15RVP_20251128_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/11/S2C_15RVP_20251128_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      },
+      {
+        "date": "2025-12-30",
+        "max_b12": 0.962399959564209,
+        "pixels": 1,
+        "flare_lon": -93.87441816386351,
+        "flare_lat": 29.752603304579175,
+        "cog": {
+          "b11": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/12/S2A_15RVP_20251230_0_L2A/B11.tif",
+          "b12": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/12/S2A_15RVP_20251230_0_L2A/B12.tif",
+          "visual": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/R/VP/2025/12/S2A_15RVP_20251230_0_L2A/TCI.tif"
+        },
+        "bounds": [
+          -93.9035089886138,
+          29.725969187657928,
+          -93.84192834118394,
+          29.780521872965892
+        ],
+        "utm_bounds": [
+          412618.3773542395,
+          3288762.7948910506,
+          418618.3773542395,
+          3294762.7948910506
+        ],
+        "epsg": 32615
+      }
+    ],
+    "id": 3605,
+    "name": "Sabine Pass LNG Terminal (Liquefaction)",
     "type": "Export"
   }
 ]

--- a/index.html
+++ b/index.html
@@ -308,6 +308,18 @@
             letter-spacing: 0.05em;
         }
 
+        .logo {
+            position: absolute;
+            bottom: 16px;
+            right: 16px;
+            width: 32px;
+            height: 32px;
+            opacity: 0.7;
+            mix-blend-mode: difference;
+            filter: invert(1);
+            pointer-events: none;
+        }
+
         /* Mobile layout */
         @media (max-width: 768px) {
             .title {
@@ -343,9 +355,12 @@
             }
 
             .info-header h3 { font-size: 12px; }
+            .intensity-chart { display: none; }  /* Hide chart on mobile to save space */
             .events-header { padding: 8px 16px; }
             .events-list { max-height: 25vh; }
             .event-item { padding: 10px 16px; }
+            .info-panel { overflow: hidden; }  /* Prevent panel scroll, only events-list scrolls */
+            .logo { display: none; }
 
             .modal-content {
                 margin: 16px;
@@ -369,6 +384,10 @@
         <div class="legend-item"><div class="legend-circle" style="background: #f8765c; color: #f8765c;"></div>Medium</div>
         <div class="legend-item"><div class="legend-circle" style="background: #b63679; color: #b63679;"></div>Low</div>
     </div>
+
+    <svg class="logo" viewBox="0 0 734.66 733.34">
+        <path fill="currentColor" d="M144.68,0c-4.92,0-9.63,1.99-13.05,5.52L4.17,136.69C1.49,139.44,0,143.12,0,146.96v440.75c-.01,3.83,1.54,7.6,4.22,10.32l128.48,130.9c2.77,2.82,6.56,4.41,10.51,4.41h224.12c49.96,0,98.27-9.63,143.61-28.63,43.81-18.36,83.08-44.69,116.71-78.24,33.61-33.53,59.98-72.67,78.37-116.33,19.01-45.12,28.64-93.17,28.64-142.81s-9.72-97.68-28.88-142.97c-18.5-43.74-44.99-83.02-78.72-116.76-33.73-33.73-73.02-60.22-116.76-78.72C465.01,9.72,416.91,0,367.33,0H144.68ZM29.46,152.93L128.48,51.03V455.48c0,8.13,6.59,14.73,14.73,14.73h224.12c56.73,0,102.88-46.15,102.88-102.88s-46.15-102.88-102.88-102.88h-73.42v-102.77h73.42c17.17,0,34.01,2.09,50.25,6.15,1.62,.41,3.24,.83,4.85,1.28,2.42,.67,4.82,1.38,7.2,2.13,31.02,9.82,59.45,27,83.11,50.67,26.1,26.1,44.31,57.97,53.46,92.74,1.49,5.66,2.74,11.4,3.74,17.2,.29,1.66,.55,3.32,.8,4.99,1.48,10.01,2.23,20.19,2.23,30.49s-.75,20.48-2.23,30.49c-.25,1.67-.51,3.33-.8,4.99-1,5.8-2.25,11.54-3.74,17.2-9.15,34.77-27.36,66.65-53.46,92.74-23.67,23.67-52.09,40.86-83.11,50.67-2.39,.76-4.79,1.47-7.2,2.13-1.61,.44-3.23,.87-4.85,1.28-16.23,4.06-33.08,6.15-50.25,6.15H29.46V152.93Zm264.45,140.98h73.42c40.48,0,73.42,32.94,73.42,73.42s-32.94,73.42-73.42,73.42h-73.42v-146.84Zm384.96,204.79c-16.9,40.12-41.13,76.09-72.02,106.91-30.92,30.85-67.02,55.05-107.29,71.93-41.71,17.48-86.19,26.34-132.22,26.34H149.39l-99.57-101.44H367.33c31.73,0,62.53-6.22,91.52-18.48,28-11.84,53.14-28.79,74.73-50.38,6.75-6.75,13.04-13.84,18.86-21.26,12.82-16.32,23.37-34.22,31.51-53.47,7.66-18.12,12.97-36.95,15.87-56.26,1.74-11.59,2.61-23.36,2.61-35.26s-.87-23.67-2.61-35.26c-2.9-19.32-8.2-38.14-15.87-56.26-8.14-19.25-18.7-37.15-31.51-53.47-5.83-7.42-12.12-14.51-18.86-21.26-21.59-21.59-46.73-38.54-74.73-50.38-28.99-12.26-59.79-18.48-91.52-18.48h-88.15c-8.13,0-14.73,6.59-14.73,14.73V440.75h-106.51V29.46h209.39c45.61,0,89.85,8.93,131.5,26.55,40.23,17.02,76.37,41.39,107.4,72.42,31.04,31.04,55.4,67.17,72.42,107.4,17.62,41.64,26.55,85.89,26.55,131.5s-8.86,89.89-26.33,131.37Z"/>
+    </svg>
 
     <div class="modal-overlay" id="about-modal">
         <div class="modal-content">
@@ -449,9 +468,14 @@
         let selectedDetection = null;
 
         // Deep-linking: update URL hash when selecting a detection
-        function updateHash(name, date) {
-            if (name && date) {
-                history.replaceState(null, '', `#${encodeURIComponent(name)}/${date}`);
+        // Format: #lat,lon/date (e.g. #-12.515,130.918/2025-01-15)
+        function updateHash(coords, date) {
+            if (coords && date) {
+                const [lon, lat] = coords;
+                // Round to 3 decimal places (~100m precision)
+                const latStr = lat.toFixed(3);
+                const lonStr = lon.toFixed(3);
+                history.replaceState(null, '', `#${latStr},${lonStr}/${date}`);
             } else {
                 history.replaceState(null, '', location.pathname);
             }
@@ -460,8 +484,11 @@
         function parseHash() {
             const hash = location.hash.slice(1);
             if (!hash) return null;
-            const [name, date] = hash.split('/').map(decodeURIComponent);
-            return name && date ? { name, date } : null;
+            const [coordsPart, date] = hash.split('/');
+            if (!coordsPart || !date) return null;
+            const [lat, lon] = coordsPart.split(',').map(parseFloat);
+            if (isNaN(lat) || isNaN(lon)) return null;
+            return { lat, lon, date };
         }
 
         // Format date as "6 Sep 2025" for historical tracking across years
@@ -673,9 +700,13 @@
             const params = parseHash();
             if (!params) return;
 
-            // Query all features at high zoom to find matching name
+            // Query all features to find matching coordinates (within tolerance)
             const features = map.querySourceFeatures('detections', { sourceLayer: 'detections' });
-            const match = features.find(f => f.properties.name === params.name);
+            const match = features.find(f => {
+                const [fLon, fLat] = f.geometry.coordinates;
+                // Match within ~100m (0.001 degrees)
+                return Math.abs(fLat - params.lat) < 0.002 && Math.abs(fLon - params.lon) < 0.002;
+            });
 
             if (match) {
                 // Navigate to feature
@@ -768,7 +799,7 @@
 
             // Update URL hash for deep-linking
             if (!skipHash && currentFeature) {
-                updateHash(currentFeature.properties.name, det.date);
+                updateHash(currentFeature.geometry.coordinates, det.date);
             }
 
             // Auto-load imagery


### PR DESCRIPTION
## Summary
This PR refactors the deep-linking system to use geographic coordinates (latitude/longitude) instead of detection names for URL hashing. This provides more reliable and precise location-based linking while also improving the UI/UX with mobile optimizations and visual enhancements.

## Key Changes

- **Deep-linking refactor**: Changed URL hash format from `#name/date` to `#lat,lon/date` (e.g., `#-12.515,130.918/2025-01-15`)
  - Coordinates are rounded to 3 decimal places (~100m precision)
  - Feature matching now uses coordinate proximity tolerance instead of name comparison
  - More robust as coordinates are unique and immutable, unlike detection names

- **Mobile UI improvements**:
  - Hide intensity chart on mobile to save screen space
  - Prevent info-panel scrolling (only events-list scrolls)
  - Hide logo on mobile devices

- **Visual enhancements**:
  - Added logo SVG element with styling (positioned bottom-right, semi-transparent with difference blend mode)
  - Logo uses `invert(1)` filter for visibility across different map backgrounds

- **Build/deployment changes**:
  - Removed GCS bucket upload step from Makefile refresh target
  - Removed deployment confirmation message

- **Data updates**: Updated detections.json with latest detection data

## Implementation Details

The coordinate-based approach provides several advantages:
- Eliminates dependency on detection name uniqueness or stability
- Enables precise location matching with configurable tolerance (currently 0.002 degrees ≈ 200m)
- Simplifies feature lookup logic by using geometric properties instead of string matching
- Better supports future features like clustering or aggregated detections at the same location