### PR TITLE
Make imagery controls half-width on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -366,6 +366,28 @@
                 padding: 20px;
                 max-width: calc(100vw - 32px);
             }
+
+            .imagery-controls {
+                display: none;
+                flex-direction: row;
+                align-items: center;
+                gap: 12px;
+                padding: 10px 16px;
+            }
+            .imagery-controls.visible { display: flex; }
+            .imagery-controls label {
+                flex: 1;
+                margin-bottom: 0;
+            }
+            .imagery-controls input[type="range"] {
+                margin-top: 4px;
+            }
+            .btn-close-imagery {
+                width: auto;
+                margin-top: 0;
+                padding: 8px 12px;
+                white-space: nowrap;
+            }
         }
     </style>
 </head>


### PR DESCRIPTION
Put opacity slider and close button side-by-side to save vertical space.