### PR TITLE
Fix mobile layout spacing for title and legend elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -308,6 +308,10 @@
 
         /* Mobile layout */
         @media (max-width: 768px) {
+            .title, .legend {
+                min-height: 72px;
+            }
+
             .title {
                 top: 8px;
                 left: 8px;


### PR DESCRIPTION
## Summary
Added minimum height constraint to title and legend elements on mobile devices to ensure consistent spacing and prevent layout collapse on smaller screens.

## Changes
- Added `min-height: 72px` CSS rule for `.title` and `.legend` elements in the mobile media query (max-width: 768px)
- This ensures both elements maintain adequate vertical space on mobile layouts, improving visual consistency and readability

## Implementation Details
The new rule is applied before the existing `.title` mobile styles, establishing a baseline minimum height that both elements respect. This prevents the elements from becoming too compressed on mobile devices while allowing them to expand naturally if content requires additional space.