### PR TITLE
Fix mobile layout: match JS breakpoint to CSS, remove title panel min-height

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -386,7 +386,7 @@ function showInfo(feature, { skipAutoSelect = false } = {}) {
     });
 
     // Snap list height to whole rows (fewer on small screens)
-    const MAX_VISIBLE_ROWS = window.innerWidth <= 600 ? 4 : 7;
+    const MAX_VISIBLE_ROWS = window.innerWidth <= 768 ? 4 : 7;
     const items = list.querySelectorAll('.event-item');
     if (items.length > 0) {
         const rowH = items[0].offsetHeight;

--- a/web/style.css
+++ b/web/style.css
@@ -427,13 +427,14 @@ html, body { width: 100%; height: 100%; font-family: 'SF Mono', 'Monaco', 'Incon
 }
 
 @media (max-width: 768px) {
-    .title, .legend { min-height: 72px; }
+    .legend { min-height: 72px; }
 
     .title {
         top: 8px;
         left: 8px;
         padding: 8px 12px;
         max-width: 200px;
+        min-height: 0;
     }
     .title h1 { font-size: 11px; }
     .title p { font-size: 10px; margin-top: 3px; }
@@ -464,7 +465,6 @@ html, body { width: 100%; height: 100%; font-family: 'SF Mono', 'Monaco', 'Incon
     .info-header h3 { font-size: 12px; }
     .intensity-chart { display: none; }
     .events-header { padding: 8px 16px; }
-    .events-list { max-height: 117px; }
     .event-item { padding: 10px 16px; }
     .info-panel { overflow: hidden; }
     .logo { display: none; }


### PR DESCRIPTION
The JS row-limit breakpoint (600px) didn't match the CSS mobile breakpoint
(768px), so devices between 601-768px got the bottom-sheet layout with 7
event rows instead of 4. Removed the dead CSS max-height on events-list
(overridden by JS inline style) and the min-height on the collapsed title
panel that added unnecessary bottom spacing.

https://claude.ai/code/session_01SybBAisrFnahizoFKj3DGf