### PR TITLE
Fix P2P debug bar hidden on mobile

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -518,6 +518,18 @@ html, body { width: 100%; height: 100%; font-family: 'SF Mono', 'Monaco', 'Incon
     .logo { display: none; }
     .panel-actions { display: none; }
 
+    .p2p-debug {
+        height: 18px;
+        font-size: 8px;
+        padding: 0 6px;
+        gap: 4px;
+        z-index: 1001;
+    }
+
+    .info-panel {
+        bottom: 18px;
+    }
+
     .modal-content {
         margin: 16px;
         padding: 20px;


### PR DESCRIPTION
The debug bar was invisible on mobile because the info panel
(bottom: 0, max-height: 45vh) covered it. Bump z-index above
the info panel and shift the info panel up by the bar height.

https://claude.ai/code/session_01M4ysidkXXvj1nGWn5sFqrm