### PR TITLE
Simplify WebRTC signaling to use single server

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -14,13 +14,8 @@ const processedMap = ydoc.getMap('processed');     // block_id:date → timestam
 const persistence = new IndexeddbPersistence('burnoff', ydoc);
 
 // P2P mesh — all Burnoff users share one room
-// Multiple signaling servers for faster, more reliable peer discovery
 const provider = new WebrtcProvider('burnoff-global', ydoc, {
-    signaling: [
-        'wss://signaling.yjs.dev',
-        'wss://y-webrtc-signaling-eu.herokuapp.com',
-        'wss://y-webrtc-signaling-us.herokuapp.com'
-    ]
+    signaling: ['wss://signaling.yjs.dev']
 });
 
 // Immediately set awareness state so signaling announces us to peers right away


### PR DESCRIPTION
## Summary
Consolidated the WebRTC signaling configuration to use a single signaling server instead of multiple redundant servers.

## Changes
- Removed secondary signaling servers (`y-webrtc-signaling-eu.herokuapp.com` and `y-webrtc-signaling-us.herokuapp.com`)
- Kept only the primary signaling server (`wss://signaling.yjs.dev`)
- Removed outdated comment about multiple signaling servers

## Details
This change simplifies the peer discovery infrastructure by relying on a single, primary signaling server. This reduces configuration complexity and potential maintenance overhead while maintaining connectivity through the stable Yjs signaling service.

https://claude.ai/code/session_01VPASYLUMEL58ZLzkwg2q9X