### PR TITLE
Block dead Heroku signaling servers and adjust UI spacing

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -3,6 +3,33 @@ import { WebrtcProvider } from 'https://cdn.jsdelivr.net/npm/y-webrtc@10.3.0/+es
 import { IndexeddbPersistence } from 'https://cdn.jsdelivr.net/npm/y-indexeddb@9.0.12/+esm';
 
 // ---------------------------------------------------------------------------
+// Block dead signaling servers the y-webrtc ESM bundle tries to contact
+// ---------------------------------------------------------------------------
+
+const _blockedSignalingHosts = [
+    'y-webrtc-signaling-eu.herokuapp.com',
+    'y-webrtc-signaling-us.herokuapp.com',
+];
+
+const _NativeWebSocket = window.WebSocket;
+window.WebSocket = function(url, protocols) {
+    try {
+        const host = new URL(url).host;
+        if (_blockedSignalingHosts.some(h => host === h)) {
+            // Return a dummy that silently does nothing
+            const noop = () => {};
+            return { readyState: 3, close: noop, send: noop,
+                     addEventListener: noop, removeEventListener: noop,
+                     set onopen(_){}, set onclose(_){}, set onmessage(_){}, set onerror(_){} };
+        }
+    } catch (_) {}
+    if (protocols !== undefined) return new _NativeWebSocket(url, protocols);
+    return new _NativeWebSocket(url);
+};
+Object.assign(window.WebSocket, _NativeWebSocket);
+window.WebSocket.prototype = _NativeWebSocket.prototype;
+
+// ---------------------------------------------------------------------------
 // P2P sync (Yjs CRDT)
 // ---------------------------------------------------------------------------
 

--- a/web/style.css
+++ b/web/style.css
@@ -211,7 +211,7 @@ html, body { width: 100%; height: 100%; font-family: 'SF Mono', 'Monaco', 'Incon
 .hidden { display: none !important; }
 
 .legend {
-    bottom: var(--edge-spacing);
+    bottom: calc(var(--edge-spacing) + 24px);
     left: var(--edge-spacing);
     padding: 12px 14px;
 }
@@ -426,7 +426,7 @@ html, body { width: 100%; height: 100%; font-family: 'SF Mono', 'Monaco', 'Incon
 
 .logo {
     position: absolute;
-    bottom: var(--edge-spacing);
+    bottom: calc(var(--edge-spacing) + 24px);
     right: var(--edge-spacing);
     width: 50px;
     height: 50px;


### PR DESCRIPTION
## Summary
This PR addresses issues with dead Heroku-hosted signaling servers that the y-webrtc library attempts to contact, and adjusts UI element positioning to prevent overlap.

## Key Changes

- **Block dead signaling servers**: Added a WebSocket proxy that intercepts connection attempts to two defunct Heroku signaling servers (`y-webrtc-signaling-eu.herokuapp.com` and `y-webrtc-signaling-us.herokuapp.com`) and returns a dummy WebSocket object that silently fails. This prevents connection timeouts and errors from these unavailable servers.

- **Fix UI spacing conflicts**: Increased the bottom offset for the legend and logo elements by 24px to prevent overlap with other UI components. Changed from `var(--edge-spacing)` to `calc(var(--edge-spacing) + 24px)` for both elements.

## Implementation Details

The WebSocket interception works by:
1. Storing a reference to the native WebSocket constructor
2. Replacing `window.WebSocket` with a wrapper function that checks the target URL's host
3. Returning a no-op dummy object for blocked hosts that implements the WebSocket interface
4. Delegating to the native WebSocket for all other connections
5. Preserving prototype chain and static properties for compatibility

This approach ensures the y-webrtc library can gracefully handle unavailable signaling servers without breaking the application.

https://claude.ai/code/session_01KnGrmnKo6sDi4iDX9YiVXc