### PR TITLE
Fix peer count detection on iOS Chrome WebRTC connections

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -270,7 +270,13 @@ persistence.once('synced', () => {
 let _lastPeerCount = 0;
 function updatePeerStatus() {
     const states = provider.awareness.getStates();
-    const peers = states.size - 1; // exclude self
+    let peers = states.size - 1; // exclude self
+    // Fallback: iOS Chrome can fail to propagate awareness states while the
+    // WebRTC data channel works fine — use actual connection count instead.
+    if (peers <= 0 && provider.room) {
+        const conns = provider.room.webrtcConns;
+        if (conns && conns.size > 0) peers = conns.size;
+    }
     const el = document.getElementById('peer-status');
     if (!el) return;
     if (peers > 0) {


### PR DESCRIPTION
## Summary
Fixed an issue where peer count would incorrectly show as zero on iOS Chrome, even when WebRTC connections were active. The awareness state propagation can fail on iOS Chrome while the underlying WebRTC data channel continues to work properly.

## Changes
- Modified `updatePeerStatus()` to fall back to actual WebRTC connection count when awareness states are unavailable
- Added a check that uses `provider.room.webrtcConns.size` as a fallback when peer count from awareness states is zero or negative
- Includes explanatory comment documenting the iOS Chrome-specific behavior

## Implementation Details
The fix maintains the primary method of counting peers via awareness states (which is more reliable when available) while providing a fallback mechanism specifically for the iOS Chrome edge case. This ensures accurate peer status display across all platforms without affecting the normal operation on other browsers.

https://claude.ai/code/session_01Xn9ey97i1zMGXRkYQPX94Q