### PR TITLE
Disable detect button at low zoom instead of showing alert

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -587,8 +587,10 @@ function updateDetectButton() {
         const qKey = `${btn.dataset.year}_${btn.dataset.quarter}`;
         return !!detected[qKey];
     });
+    const tooZoomedOut = map.getZoom() < MIN_DETECT_ZOOM;
     const btn = document.getElementById('detect-btn');
-    btn.disabled = allDetected;
+    btn.disabled = allDetected || tooZoomedOut;
+    btn.title = tooZoomedOut ? 'Zoom in to at least level 11' : '';
 }
 
 
@@ -1235,11 +1237,6 @@ function cleanupDetection() {
 }
 
 async function startDetection() {
-    if (map.getZoom() < MIN_DETECT_ZOOM) {
-        alert('Zoom in to at least level 11 before running detection.');
-        return;
-    }
-
     if (detectWorker) { detectWorker.terminate(); detectWorker = null; }
     _isDetecting = true;
     _preSessionKeys = new Set(processedMap.keys());
@@ -1335,6 +1332,7 @@ let _quarterIndicatorTimeout;
 map.on('moveend', () => {
     clearTimeout(_quarterIndicatorTimeout);
     _quarterIndicatorTimeout = setTimeout(updateQuarterIndicators, 300);
+    updateDetectButton();
 });
 
 map.on('load', () => {


### PR DESCRIPTION
Replace the alert('Zoom in to at least level 11...') with disabling
the detect button when zoomed out too far. The button re-enables
automatically on moveend when the user zooms in past the threshold,
and shows a tooltip explaining the requirement.

https://claude.ai/code/session_01XqTNmX84FF8bdaHBv6AHNQ