### PR TITLE
Standardize quarter button sizes with spacers for future quarters

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -389,7 +389,13 @@ function initQuarterPicker() {
         row.appendChild(label);
 
         const maxQ = (year === currentYear) ? currentQuarter : 4;
-        for (let q = 1; q <= maxQ; q++) {
+        for (let q = 1; q <= 4; q++) {
+            if (q > maxQ) {
+                const spacer = document.createElement('span');
+                spacer.className = 'quarter-spacer';
+                row.appendChild(spacer);
+                continue;
+            }
             const btn = document.createElement('button');
             btn.className = 'quarter-btn';
             btn.textContent = `Q${q}`;

--- a/web/style.css
+++ b/web/style.css
@@ -214,6 +214,9 @@ html, body { width: 100%; height: 100%; font-family: 'SF Mono', 'Monaco', 'Incon
     color: var(--text-hint);
     background: transparent;
 }
+.quarter-spacer {
+    flex: 1;
+}
 .hidden { display: none !important; }
 
 .legend {


### PR DESCRIPTION
Instead of only rendering buttons up to the current quarter (causing
Q1 to stretch full-width on its own), always lay out 4 columns per
row and insert invisible flex spacers for quarters that haven't
occurred yet.

https://claude.ai/code/session_01AexwtQLRbrhfrk5ywcHGMe