### PR TITLE
Fix detections lost on reload on iOS (WebKit) browsers

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -64,10 +64,28 @@ const syncManager = new SyncManager({
 // Set initial awareness
 syncManager.setLocalAwareness({ active: true, t: Date.now() });
 
+// Flush all pending data to IndexedDB.
+// Called on beforeunload, visibilitychange (hidden), and pagehide to ensure
+// persistence on iOS WebKit which kills pages aggressively on reload/navigate.
+function flushAllPendingData() {
+    flushPendingBlocks();
+    store.flush();
+}
+
 // Clear awareness on page unload
 window.addEventListener('beforeunload', () => {
+    flushAllPendingData();
     syncManager.setLocalAwareness(null);
     mesh.disconnect();
+});
+
+// iOS WebKit (used by Chrome/Safari on iOS) does not reliably fire
+// beforeunload. visibilitychange and pagehide are the reliable signals.
+document.addEventListener('visibilitychange', () => {
+    if (document.hidden) flushAllPendingData();
+});
+window.addEventListener('pagehide', () => {
+    flushAllPendingData();
 });
 
 // Heartbeat: update timestamp every 15s

--- a/web/store.js
+++ b/web/store.js
@@ -75,6 +75,15 @@ export class Store {
         }, FLUSH_INTERVAL);
     }
 
+    /** Flush dirty entries to IndexedDB immediately (cancel any pending timer). */
+    flush() {
+        if (this._flushTimer) {
+            clearTimeout(this._flushTimer);
+            this._flushTimer = null;
+        }
+        this._flush();
+    }
+
     _flush() {
         if (!this._db || this._dirty.size === 0) return;
         const entries = Array.from(this._dirty.entries());


### PR DESCRIPTION
iOS WebKit (used by all browsers on iOS including Chrome) does not
reliably fire beforeunload and kills pages aggressively on reload.
The 500ms batched flush timer in Store meant pending IndexedDB writes
were lost. Add visibilitychange and pagehide listeners that flush
both the app-level pending block queue and the Store dirty queue
immediately, and also flush in beforeunload as a fallback.

https://claude.ai/code/session_019rTGRpQz6KAAWjXZZxCGdP