### PR TITLE
Fix oversized fonts on mobile landscape for modal and image picker

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -14,7 +14,7 @@
 }
 
 * { margin: 0; padding: 0; box-sizing: border-box; }
-html, body { width: 100%; height: 100%; font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code', monospace; }
+html, body { width: 100%; height: 100%; font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code', monospace; -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
 #map { width: 100%; height: 100%; background: #000; }
 .maplibregl-ctrl, .maplibregl-ctrl-logo, .maplibregl-ctrl-attrib { display: none !important; }
 
@@ -633,4 +633,39 @@ html, body { width: 100%; height: 100%; font-family: 'SF Mono', 'Monaco', 'Incon
     .modal-content h2 { font-size: 13px; margin-bottom: 12px; }
     .modal-content p { margin-bottom: 12px; }
     .modal-citations { font-size: 10px; padding-top: 10px; margin-top: 4px; }
+}
+
+@media (max-height: 500px) and (orientation: landscape) {
+    .modal-content {
+        margin: 12px;
+        padding: 16px 20px;
+        max-width: calc(100vw - 24px);
+        font-size: 11px;
+        line-height: 1.45;
+        max-height: calc(100vh - 24px);
+        overflow-y: auto;
+    }
+    .modal-content h2 { font-size: 12px; margin-bottom: 8px; }
+    .modal-content p { margin-bottom: 8px; }
+    .modal-citations { font-size: 10px; padding-top: 8px; margin-top: 4px; }
+    .modal-dismiss { margin-top: 8px; }
+
+    .info-panel {
+        top: auto;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        width: 100%;
+        max-height: 45vh;
+        border-left: none;
+        border-right: none;
+        border-bottom: none;
+    }
+    .info-header h3 { font-size: 12px; }
+    .event-date { font-size: 10px; }
+    .event-meta { font-size: 10px; }
+    .events-header { padding: 8px 16px; }
+    .event-item { padding: 8px 16px; }
+    .intensity-chart { display: none; }
+    .panel-actions { display: none; }
 }


### PR DESCRIPTION
Mobile browsers inflate font sizes in narrow columns via text-size-adjust
when in landscape mode. Added text-size-adjust: 100% to prevent this, and
a landscape-specific media query (max-height: 500px) for the about modal
and info panel to use appropriately scaled fonts and layout.

https://claude.ai/code/session_018iuPJNwsoQTmji6apDvKvr