### PR TITLE
Add daily VNF backfill automation and remove nightly toggle

### DIFF
--- a/.github/workflows/vnf-backfill.yml
+++ b/.github/workflows/vnf-backfill.yml
@@ -1,0 +1,35 @@
+name: VNF daily backfill
+
+on:
+  schedule:
+    # Run daily at 10:00 UTC (after all VIIRS orbits for the previous day)
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install requests beautifulsoup4 lxml duckdb
+
+      - name: Authenticate with Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up gcloud CLI
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Run backfill
+        env:
+          EOG_EMAIL: ${{ secrets.EOG_EMAIL }}
+          EOG_PASSWORD: ${{ secrets.EOG_PASSWORD }}
+          VNF_PASSWORD: ${{ secrets.VNF_PASSWORD }}
+        run: python scripts/backfill_vnf.py

--- a/.github/workflows/vnf-backfill.yml
+++ b/.github/workflows/vnf-backfill.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Authenticate with Google Cloud
         uses: google-github-actions/auth@v2
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          credentials_json: ${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}
 
       - name: Set up gcloud CLI
         uses: google-github-actions/setup-gcloud@v2

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: serve signal test deploy terminals vnf vnf-upload vnf-deploy accumulations profiles vendor help
+.PHONY: serve signal test deploy terminals vnf vnf-upload vnf-deploy vnf-backfill accumulations profiles vendor help
 
 terminals: web/terminals.geojson
 
@@ -47,6 +47,9 @@ vnf-upload: web/vnf.parquet
 
 vnf-deploy: vnf vnf-upload
 
+vnf-backfill:
+	uv run --with requests,beautifulsoup4,lxml,duckdb scripts/backfill_vnf.py
+
 accumulations: web/accumulations.geojson
 
 web/accumulations.geojson: scripts/fetch_accumulations.py
@@ -82,6 +85,7 @@ help:
 	@echo "make vnf        - Build VNF parquet from EOG profile CSVs"
 	@echo "make vnf-upload - Upload VNF parquet to GCS"
 	@echo "make vnf-deploy - Build + upload VNF parquet (one step)"
+	@echo "make vnf-backfill - Backfill recent nightly VNF data into parquet"
 	@echo "make profiles    - Download VNF profiles for facility-adjacent flares"
 	@echo "make accumulations - Fetch oil/gas field polygons from MapStand"
 	@echo "make deploy     - Deploy signaling worker to Cloudflare"

--- a/scripts/backfill_vnf.py
+++ b/scripts/backfill_vnf.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+"""Daily VNF backfill: fetch recent nightly detections and append to the parquet.
+
+Downloads nightly ez-format CSVs from EOG for dates after the last date in the
+existing parquet, matches each detection to the nearest known flare by proximity,
+and appends new daily rows.  When profiles are rebuilt (`make vnf`), the full
+profile-based parquet replaces everything, including these backfill rows.
+
+Requires EOG_EMAIL and EOG_PASSWORD environment variables (or .env file).
+
+If VNF_PASSWORD is set, downloads the current parquet from GCS before backfilling
+and uploads the result after.  Otherwise works with a local web/vnf.parquet.
+
+Usage: uv run --with requests,beautifulsoup4,lxml,duckdb scripts/backfill_vnf.py
+"""
+
+import csv
+import gzip
+import io
+import os
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import date, timedelta
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.join(PROJECT_ROOT, "scripts"))
+
+OUTPUT = os.path.join(PROJECT_ROOT, "web", "vnf.parquet")
+BASE_URL = "https://eogdata.mines.edu/wwwdata/viirs_products/vnf/v30/rearrange"
+SATELLITES = ["npp", "j01", "j02"]
+WORKERS = 20
+MATCH_RADIUS_KM = 5  # max distance to assign a detection to a known flare
+
+
+def load_dotenv():
+    env_path = os.path.join(PROJECT_ROOT, ".env")
+    if not os.path.isfile(env_path):
+        return
+    with open(env_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            key = key.strip()
+            value = value.strip().strip("'\"")
+            if key and key not in os.environ:
+                os.environ[key] = value
+
+
+def authenticate():
+    from fetch_vnf_profiles import authenticate as eog_auth, verify_auth
+    session, html = eog_auth()
+    if not html or "site_" not in html:
+        verify_auth(session)
+    return session
+
+
+def gcs_parquet_url():
+    """Derive GCS URL from VNF_PASSWORD, or return None."""
+    import hashlib
+    pw = os.environ.get("VNF_PASSWORD")
+    if not pw:
+        return None
+    h = hashlib.sha256(pw.encode()).hexdigest()[:16]
+    return f"https://storage.googleapis.com/burnoff-data/vnf-{h}.parquet"
+
+
+def download_from_gcs(url, dest):
+    """Download parquet from GCS. Returns True on success."""
+    import requests as req
+    try:
+        resp = req.get(url, timeout=120)
+        if resp.ok:
+            with open(dest, "wb") as f:
+                f.write(resp.content)
+            print(f"  Downloaded {len(resp.content) / 1e6:.1f} MB from GCS")
+            return True
+        print(f"  GCS download failed: HTTP {resp.status_code}")
+    except Exception as e:
+        print(f"  GCS download error: {e}")
+    return False
+
+
+def upload_to_gcs(src):
+    """Upload parquet to GCS using gsutil/gcloud."""
+    import hashlib, subprocess
+    pw = os.environ.get("VNF_PASSWORD")
+    if not pw:
+        print("  No VNF_PASSWORD — skipping GCS upload")
+        return False
+    h = hashlib.sha256(pw.encode()).hexdigest()[:16]
+    dest = f"gs://burnoff-data/vnf-{h}.parquet"
+    try:
+        subprocess.run(
+            ["gcloud", "storage", "cp", src, dest],
+            check=True, capture_output=True, text=True,
+        )
+        print(f"  Uploaded to {dest}")
+        return True
+    except FileNotFoundError:
+        print("  gcloud CLI not found — skipping upload")
+    except subprocess.CalledProcessError as e:
+        print(f"  Upload failed: {e.stderr.strip()}")
+    return False
+
+
+def haversine_km(lat1, lon1, lat2, lon2):
+    import math
+    R = 6371
+    dLat = math.radians(lat2 - lat1)
+    dLon = math.radians(lon2 - lon1)
+    a = (math.sin(dLat / 2) ** 2 +
+         math.cos(math.radians(lat1)) * math.cos(math.radians(lat2)) *
+         math.sin(dLon / 2) ** 2)
+    return R * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+
+def load_flare_positions(db):
+    """Load known flare positions from existing parquet. Returns dict {flare_id: (lat, lon)}."""
+    if not os.path.exists(OUTPUT):
+        return {}
+    rows = db.execute(f"""
+        SELECT flare_id, FIRST(lat) AS lat, FIRST(lon) AS lon
+        FROM '{OUTPUT}'
+        GROUP BY flare_id
+    """).fetchall()
+    return {int(r[0]): (float(r[1]), float(r[2])) for r in rows}
+
+
+def load_max_date(db):
+    """Get the latest date in the existing parquet."""
+    if not os.path.exists(OUTPUT):
+        return None
+    row = db.execute(f"SELECT MAX(date) FROM '{OUTPUT}'").fetchone()
+    d = row[0] if row else None
+    if d and not isinstance(d, date):
+        from datetime import datetime
+        d = datetime.strptime(str(d)[:10], "%Y-%m-%d").date()
+    return d
+
+
+def build_spatial_index(flare_positions):
+    """Build a grid index for fast nearest-flare lookups."""
+    from collections import defaultdict
+    grid = defaultdict(list)
+    for fid, (lat, lon) in flare_positions.items():
+        key = (int(lat), int(lon))
+        grid[key].append((fid, lat, lon))
+    return grid
+
+
+def find_nearest_flare(lat, lon, grid, radius_km):
+    """Find the nearest known flare within radius. Returns flare_id or None."""
+    import math
+    clat, clon = int(lat), int(lon)
+    best_dist = radius_km + 1
+    best_fid = None
+    search_deg = max(1, math.ceil(radius_km / 111))
+    for dlat in range(-search_deg, search_deg + 1):
+        for dlon in range(-search_deg, search_deg + 1):
+            for fid, flat, flon in grid.get((clat + dlat, clon + dlon), []):
+                d = haversine_km(lat, lon, flat, flon)
+                if d < best_dist:
+                    best_dist = d
+                    best_fid = fid
+    return best_fid if best_dist <= radius_km else None
+
+
+def download_nightly(session, sat, d):
+    """Download a single nightly ez CSV and return all rows."""
+    url = (f"{BASE_URL}/{d.year}/{d.month:02d}/{sat}/"
+           f"VNF_{sat}_d{d.strftime('%Y%m%d')}_noaa_v30-ez.csv.gz")
+    try:
+        resp = session.get(url, timeout=60)
+        if resp.status_code == 404:
+            return []
+        if not resp.ok:
+            return []
+        data = gzip.decompress(resp.content)
+        text = data.decode("utf-8", errors="replace")
+        reader = csv.DictReader(io.StringIO(text))
+        rows = []
+        for row in reader:
+            try:
+                lat = float(row["Lat_GMTCO"])
+                lon = float(row["Lon_GMTCO"])
+            except (ValueError, KeyError):
+                continue
+            # Only nighttime detections
+            if row.get("Sunlit", "0") == "1":
+                continue
+            rows.append(row)
+        return rows
+    except Exception:
+        return []
+
+
+def main():
+    load_dotenv()
+    import duckdb
+
+    db = duckdb.connect()
+
+    # Download from GCS if available
+    gcs_url = gcs_parquet_url()
+    if gcs_url and not os.environ.get("BACKFILL_SKIP_DOWNLOAD"):
+        print("Downloading current parquet from GCS...")
+        download_from_gcs(gcs_url, OUTPUT)
+
+    # Load existing state
+    flare_positions = load_flare_positions(db)
+    max_date = load_max_date(db)
+
+    if not flare_positions:
+        print("No existing parquet with flare positions found. Run `make vnf` first.")
+        sys.exit(1)
+
+    print(f"Loaded {len(flare_positions)} known flares, latest date: {max_date}")
+
+    # Determine date range to backfill
+    yesterday = date.today() - timedelta(days=1)
+    start = max_date + timedelta(days=1) if max_date else yesterday - timedelta(days=7)
+
+    if start > yesterday:
+        print("Already up to date.")
+        return
+
+    num_days = (yesterday - start).days + 1
+    print(f"Backfilling {num_days} day(s): {start} to {yesterday}")
+
+    # Authenticate with EOG
+    print("Authenticating with EOG...")
+    session = authenticate()
+    print("  Authenticated")
+
+    # Build spatial index for flare matching
+    grid = build_spatial_index(flare_positions)
+
+    # Download nightly data
+    jobs = []
+    d = start
+    while d <= yesterday:
+        for sat in SATELLITES:
+            jobs.append((sat, d))
+        d += timedelta(days=1)
+
+    print(f"Fetching {len(jobs)} files ({len(SATELLITES)} satellites x {num_days} days)...")
+
+    all_rows = []
+    done = 0
+    t0 = time.time()
+
+    with ThreadPoolExecutor(max_workers=WORKERS) as pool:
+        futures = {
+            pool.submit(download_nightly, session, sat, d): (sat, d)
+            for sat, d in jobs
+        }
+        for future in as_completed(futures):
+            rows = future.result()
+            done += 1
+            if rows:
+                all_rows.extend(rows)
+            if done % 50 == 0 or done == len(jobs):
+                elapsed = time.time() - t0
+                rate = done / elapsed if elapsed > 0 else 0
+                sys.stdout.write(
+                    f"\r  {done}/{len(jobs)} files "
+                    f"({len(all_rows)} rows, {rate:.0f} files/s)  "
+                )
+                sys.stdout.flush()
+
+    print(f"\n  {len(all_rows)} total nightly rows")
+
+    if not all_rows:
+        print("No new nightly data found.")
+        return
+
+    # Match detections to known flares
+    print("Matching detections to known flares...")
+    # Group by (flare_id, date) for daily aggregation
+    from collections import defaultdict
+    daily = defaultdict(list)  # (flare_id, date_str) -> list of pass dicts
+    matched = 0
+    unmatched = 0
+
+    for row in all_rows:
+        try:
+            lat = float(row["Lat_GMTCO"])
+            lon = float(row["Lon_GMTCO"])
+        except (ValueError, KeyError):
+            continue
+
+        fid = find_nearest_flare(lat, lon, grid, MATCH_RADIUS_KM)
+        if fid is None:
+            unmatched += 1
+            continue
+
+        matched += 1
+        date_str = row.get("Date_Mscan", "")[:10].replace("/", "-")
+        cloud_mask = int(row.get("Cloud_Mask", 1))
+        temp_bb = float(row.get("Temp_BB", 999999))
+        rh = float(row.get("RH", 999999))
+
+        daily[(fid, date_str)].append({
+            "cloud_mask": cloud_mask,
+            "temp_bb": temp_bb,
+            "rh": rh,
+        })
+
+    print(f"  {matched} matched, {unmatched} unmatched (no known flare within {MATCH_RADIUS_KM} km)")
+
+    if not daily:
+        print("No matched detections to append.")
+        return
+
+    # Build new rows (same aggregation logic as build_vnf.py)
+    new_rows = []
+    for (fid, date_str), passes in daily.items():
+        clear = any(p["cloud_mask"] == 0 for p in passes)
+        detected = any(p["cloud_mask"] == 0 and p["temp_bb"] != 999999 for p in passes)
+        clear_detected = [p for p in passes if p["cloud_mask"] == 0 and p["temp_bb"] != 999999]
+        rh_mw = (sum(p["rh"] for p in clear_detected if p["rh"] != 999999) /
+                 len([p for p in clear_detected if p["rh"] != 999999])) if any(
+            p["rh"] != 999999 for p in clear_detected) else 0
+        temp_k = (sum(p["temp_bb"] for p in clear_detected) /
+                  len(clear_detected)) if clear_detected else 0
+        lat, lon = flare_positions[fid]
+
+        new_rows.append((
+            fid, lat, lon, date_str,
+            clear, detected, rh_mw, temp_k,
+            len(passes), "", "", "", "", "",
+        ))
+
+    print(f"  {len(new_rows)} new daily rows to append")
+
+    # Read existing parquet and append
+    print("Appending to parquet...")
+    db.execute(f"""
+        CREATE TABLE existing AS SELECT * FROM '{OUTPUT}'
+    """)
+
+    # Remove any existing rows for dates we're backfilling (in case of re-run)
+    date_strs = list(set(date_str for _, date_str in daily.keys()))
+    date_list = ", ".join(f"'{d}'" for d in date_strs)
+    deleted = db.execute(f"""
+        DELETE FROM existing WHERE CAST(date AS VARCHAR) IN ({date_list})
+    """).fetchone()
+
+    # Insert new rows
+    db.execute("""
+        CREATE TABLE new_rows (
+            flare_id INT, lat DOUBLE, lon DOUBLE, date DATE,
+            clear BOOLEAN, detected BOOLEAN, rh_mw DOUBLE, temp_k DOUBLE,
+            n_passes INT, type VARCHAR, category VARCHAR, country VARCHAR,
+            facility_type VARCHAR, facility_name VARCHAR
+        )
+    """)
+    db.executemany("INSERT INTO new_rows VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)", new_rows)
+    db.execute("INSERT INTO existing SELECT * FROM new_rows")
+
+    total = db.execute("SELECT count(*) FROM existing").fetchone()[0]
+    db.execute(f"""
+        COPY (SELECT * FROM existing ORDER BY flare_id, date)
+        TO '{os.path.abspath(OUTPUT)}'
+        (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 50000)
+    """)
+
+    size_mb = os.path.getsize(os.path.abspath(OUTPUT)) / 1e6
+    print(f"  Written {total:,} rows ({size_mb:.1f} MB)")
+
+    # Upload to GCS
+    if gcs_url:
+        print("Uploading to GCS...")
+        upload_to_gcs(os.path.abspath(OUTPUT))
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/web/app.js
+++ b/web/app.js
@@ -10,7 +10,6 @@ import { initVNF, resetVNF, queryVNF, queryVNFFlare, isReady as vnfReady } from 
 
 let currentMode = null;
 let _vnfInitStarted = false;
-let _vnfNightlyMode = false; // true = show raw nightly detections
 let _vnfFeatures = null;   // cached VNF FeatureCollection (clustered)
 let _vnfRawFeatures = null; // raw features from last queryVNF
 let _vnfRefreshTimer = null;
@@ -60,7 +59,6 @@ async function promptVNFPassword() {
 }
 
 async function getVNFUrl() {
-    if (_vnfNightlyMode) return 'vnf_nightly.parquet';
     if (!VNF_BUCKET || location.hostname === 'localhost') return 'vnf.parquet';
     const cached = getVNFSession();
     if (cached) return cached;
@@ -771,14 +769,6 @@ function switchMode(mode) {
             refreshVNF();
         }
     } else {
-        // Reset nightly toggle when leaving VNF mode
-        if (_vnfNightlyMode) {
-            _vnfNightlyMode = false;
-            _vnfInitStarted = false;
-            resetVNF();
-            const cb = document.getElementById('vnf-nightly-toggle');
-            if (cb) cb.checked = false;
-        }
         // Restore S2 features
         rebuildDetections();
         ensureDetectionLayer();
@@ -2206,24 +2196,6 @@ document.getElementById('collapse-toggle').addEventListener('click', () => {
 // Mode toggle
 document.querySelectorAll('.mode-btn').forEach(btn => {
     btn.addEventListener('click', () => switchMode(btn.dataset.mode));
-});
-
-// VNF nightly toggle — swap between profile parquet and raw nightly detections
-document.getElementById('vnf-nightly-toggle')?.addEventListener('change', async (e) => {
-    _vnfNightlyMode = e.target.checked;
-    _vnfInitStarted = false;
-    resetVNF();
-    const url = await getVNFUrl();
-    if (!url) return;
-    _vnfInitStarted = true;
-    try {
-        await initVNF(url);
-        if (currentMode === 'vnf') refreshVNF();
-    } catch (err) {
-        console.error('VNF nightly init error:', err);
-        _vnfInitStarted = false;
-        resetVNF();
-    }
 });
 
 // Deep link: navigate to a VNF flare by hash (#vnf/12345)

--- a/web/index.html
+++ b/web/index.html
@@ -34,10 +34,6 @@
             <button class="mode-btn active" data-mode="s2">S2</button>
             <button class="mode-btn" data-mode="vnf">VNF</button>
         </div>
-        <label class="vnf-nightly-label" id="vnf-nightly-label">
-            <input type="checkbox" id="vnf-nightly-toggle">
-            <span>Nightly detections</span>
-        </label>
         <div class="detect-separator"></div>
         <div class="peer-status" id="peer-status"></div>
         <div class="map-loc-section">

--- a/web/style.css
+++ b/web/style.css
@@ -124,18 +124,6 @@ html, body { width: 100%; height: 100%; font-family: 'Inter', -apple-system, Bli
     color: var(--text-secondary);
 }
 
-/* VNF nightly toggle — only visible in VNF mode */
-.vnf-nightly-label {
-    display: none;
-    align-items: center;
-    gap: 6px;
-    margin: 8px 0 0 0;
-    font-size: var(--font-xs);
-    color: var(--text-faint);
-    cursor: pointer;
-}
-.vnf-nightly-label input { margin: 0; cursor: pointer; }
-#title-panel:not(.mode-s2) .vnf-nightly-label { display: flex; }
 
 /* Hide S2-only elements when not in S2 mode */
 #title-panel:not(.mode-s2) .s2-only { display: none; }


### PR DESCRIPTION
## Summary
This PR adds automated daily backfilling of VNF (Visible Nighttime Fires) data and removes the manual nightly detection toggle feature. The backfill script fetches recent nightly detections from EOG, matches them to known flares by proximity, and appends aggregated daily rows to the parquet file. A GitHub Actions workflow runs this daily after all VIIRS orbits complete.

## Key Changes

- **New backfill script** (`scripts/backfill_vnf.py`): Automates daily VNF data updates by:
  - Downloading nightly ez-format CSVs from EOG for dates after the last parquet entry
  - Matching detections to known flares using spatial indexing (within 5 km radius)
  - Aggregating matched detections into daily rows with cloud/temperature metrics
  - Appending results to the existing parquet file
  - Supporting GCS upload/download via `VNF_PASSWORD` for secure data persistence

- **GitHub Actions workflow** (`.github/workflows/vnf-backfill.yml`): Runs the backfill script daily at 10:00 UTC with EOG and GCS credentials

- **Removed nightly toggle UI**: Deleted the checkbox and associated JavaScript/CSS that allowed users to swap between profile-based and raw nightly detection views. This simplifies the interface since backfill now keeps the parquet continuously updated

- **Makefile updates**: Added `vnf-backfill` target for manual backfill runs

## Implementation Details

- Uses concurrent downloads (20 workers) to efficiently fetch multiple satellite/date combinations
- Implements haversine distance calculation for spatial matching
- Builds a grid-based spatial index for O(1) nearest-flare lookups
- Deduplicates rows for re-run safety by deleting existing entries for backfilled dates before appending
- Aggregates multiple passes per flare/date into single rows with averaged metrics (RH, temperature)
- Integrates with existing `fetch_vnf_profiles.py` authentication for EOG access

https://claude.ai/code/session_01HYNN7vDg4KhK8DM1HKDPQq