### PR TITLE
vnf: divide by the nights we read, not by 91

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,21 +216,27 @@ and shown in the detail card, NOT yet a gate. The formula was tuned in
 
 ## VNF Data Pipeline
 
-The pipeline lives in the sibling etl repo (`~/Tools/etl`): EOG profile CSVs
-(one per flare site, every satellite pass since 2012) are aggregated to daily
-level per flare and written to a ZSTD-compressed Parquet file (~6 MB, ~1.8M
-rows), refreshed nightly by `etl/vnf.yml`.
+The pipeline lives in the sibling etl repo (`~/Tools/etl`, see `vnf/REBUILD.md`).
+It generates the calendar itself — every flare, every night from 2012-03-01 to
+today — and lets EOG supply detections only, so a night with no detection is a
+row saying "nothing seen", not an absence. Whether we could have seen anything
+is our own call: ERA5 total cloud cover sampled at each site's real VIIRS
+overpass hours, clear at `tcc < 0.6`.
 
 ```
-Profile CSVs → nighttime filter → daily aggregation → parquet
-                                       ↑
-                  terminals.geojson → haversine filter (6 km)
-                  flare index      → metadata enrichment (type, category, country)
+flare × night calendar → EOG profile CSVs   → detections (Planck fits)
+                       → ERA5 tcc at overpass hours → clear / unobserved
+                       → terminals.geojson (6 km) → flare index (type, category, country)
 ```
 
-Parquet schema: `flare_id, lat, lon, date, clear, detected, rh_mw, temp_k,
-flow_mcm, n_passes, type, category, country`. Coordinates are stable per-flare
-averages (from profile passes), not per-pass positions. `flow_mcm` carries
+Daily parquet (`views/vnf/data.parquet`): `flare_id, lat, lon, date, clear,
+detected, tcc, rh_mw, temp_k, flow_mcm, looks, profiled`. `clear` is BOOLEAN and
+NULL means unobserved — never conflate it with cloudy. `profiled` survives from
+the old build and still gates the same way, but it now says a satellite flew and
+we read the sky rather than that EOG chose to write a row; 98.8% of flare-nights
+across the archive are observed. `type, category, country` moved out to
+`views/vnf/flares.parquet` and `n_passes` is gone. Coordinates are stable
+per-flare averages (from profile passes), not per-pass positions. `flow_mcm` carries
 EOG's own per-pass `Flow_Rate` (daily-averaged like `rh_mw`; 0 on
 nightly-backfilled rows — the ez CSVs have no flow) but is NOT displayed:
 the UI's MCM/d column is `rh_mw × 0.0315`, the JZ-RH VNF v3 calibration
@@ -246,16 +252,33 @@ so queries can go straight to EOG's numbers without trusting the aggregation.
 Rebuild + re-upload after `make -C ../etl vnf-profiles` refreshes the CSVs. (The nightly backfill appends to the AGGREGATE only; the raw parquet is
 profiles-only and regenerates from the CSV corpus.)
 
-The web query groups by `flare_id`, computes `total_dates`, `profiled_dates`,
-`clear_dates`, `detection_dates`, and returns a detection list with
-`date, rh_mw, temp_k`. Persistence = `detection_dates / clear_dates` (real
-cloud-free denominator), **but only where `coverage` clears `COVERAGE_MIN`**.
-EOG stopped recording an overpass for every flare every night on 2025-10-01, so
-`clear_dates` can be a fraction of the window it appears to cover while
-`detection_dates` is intact — which roughly doubles the ratio. `coverage` is
-`profiled_dates` over the nights in the selected quarters; below 0.8 persistence
-is null, the card shows '—' and the layer filter drops the flare rather than
-ranking it. See `data-desk/docs/archive/vnf.md`.
+The viewport tier is `views/vnf/quarters.parquet` (flare × quarter, last four
+calendar years): `days, profiled_days, clear_days, detected_days,
+detected_any_days, rh_sum, rh_max`. `days` is the exact night count in the
+quarter, `detected_days` counts detections on nights we could see, and
+`detected_any_days` counts every detection including cloudy ones. **Never divide
+`detected_any_days` by `clear_days`** — that pairing is what broke `lng-flaring`.
+
+The web query sums those to `total_dates`, `profiled_dates`, `clear_dates`,
+`detection_dates`, `detection_any` per flare, and returns a detection list with
+`date, rh_mw`. Two ratios come out of it:
+
+- `persistence` = `detection_dates / clear_dates` — numerator and denominator on
+  the same nights, so it is a rate. Null, not 0, where `clear_dates` is 0 (a
+  window holding no clear night measures nothing) or where `coverage` falls
+  below `COVERAGE_MIN`. The card shows '—' and the layer filter drops the flare
+  rather than ranking it.
+- `avg_rh` = `rh_sum / detection_any` — `rh_sum` spans every detection, so its
+  mean divides by every detection.
+
+`coverage` is `profiled_dates / total_dates`: the share of the selected window's
+nights we read the sky for, over the exact night count rather than a 91-night
+approximation. Whole nights are missing globally or not at all, so it catches
+platform outages and the trailing weeks the ERA5 series has not reached, not
+per-site absence. Quarters run 0.93–1.00 read against 0.68 for one still
+filling, and `COVERAGE_MIN` (0.8) sits in that gap — so the current quarter
+selected alone greys out until the backfill has caught up on ~80% of its
+nights. See `data-desk/docs/archive/vnf.md`.
 
 ## P2P Sync
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,8 +218,9 @@ and shown in the detail card, NOT yet a gate. The formula was tuned in
 
 The pipeline lives in the sibling etl repo (`~/Tools/etl`, see `vnf/REBUILD.md`).
 It generates the calendar itself — every flare, every night from 2012-03-01 to
-today — and lets EOG supply detections only, so a night with no detection is a
-row saying "nothing seen", not an absence. Whether we could have seen anything
+wherever the cloud series ends, about five days back — and lets EOG supply
+detections only, so a night with no detection is a row saying "nothing seen",
+not an absence. Whether we could have seen anything
 is our own call: ERA5 total cloud cover sampled at each site's real VIIRS
 overpass hours, clear at `tcc < 0.6`.
 
@@ -273,12 +274,15 @@ The web query sums those to `total_dates`, `profiled_dates`, `clear_dates`,
 
 `coverage` is `profiled_dates / total_dates`: the share of the selected window's
 nights we read the sky for, over the exact night count rather than a 91-night
-approximation. Whole nights are missing globally or not at all, so it catches
-platform outages and the trailing weeks the ERA5 series has not reached, not
-per-site absence. Quarters run 0.93–1.00 read against 0.68 for one still
-filling, and `COVERAGE_MIN` (0.8) sits in that gap — so the current quarter
-selected alone greys out until the backfill has caught up on ~80% of its
-nights. See `data-desk/docs/archive/vnf.md`.
+approximation. The calendar ends where the cloud series ends, so it no longer
+counts nights ERA5 has not reached; what is left to catch is platform outages,
+and those are per-site — one platform grounded still leaves the other flying,
+and a single platform does not reach every site every night. `COVERAGE_MIN`
+(0.8) is therefore a per-site gate rather than a per-quarter one: whole quarters
+average 0.86–1.00 read, and the flares falling below the threshold are the ones
+an outage covered — 708 and 644 of ~11,800 mapped flares in the two 2024 outage
+quarters, 289 of 6,982 in the quarter in progress. See
+`data-desk/docs/archive/vnf.md`.
 
 ## P2P Sync
 

--- a/web/card.js
+++ b/web/card.js
@@ -103,17 +103,21 @@ export function cardTitle(p) {
 
 export function cardHtml(p) {
     const cfg = modeConf();
+    const vnf = isVnf();
     // vnf features carry range-scoped aggregates from the quarterly rollup
     // (detections load lazily); s2 derives metrics from the embedded list
-    const m = isVnf()
+    const m = vnf
         ? { detection_count: p.detection_count, observations: p.observations, persistence: p.persistence }
         : quarterMetrics(p, parseDets(p), quarterKeys());
     const cfLabel = p.passes && m.observations != null
         ? `Cloud-free (${Math.round(m.observations / p.passes * 100)}%)` : 'Cloud-free obs.';
+    // vnf: the count is the nights we could see the site and it was lit — fewer
+    // than the dates listed below, which include cloudy ones — over nights a
+    // satellite flew and we read the sky. the four read as one chain.
     const stats = [
-        ['Detections', m.detection_count],
+        [vnf ? 'Detections (clear)' : 'Detections', m.detection_count],
         ['Persistence', m.persistence != null ? `${Math.round(m.persistence * 100)}%` : '—'],
-        ['Passes', p.passes ?? '—'],
+        [vnf ? 'Nights read' : 'Passes', p.passes ?? '—'],
         [cfLabel, m.observations ?? '—'],
     ].map(([k, v]) => `<div><span class="dd-secondary">${k}</span><span>${v}</span></div>`).join('');
     return `

--- a/web/clustering.js
+++ b/web/clustering.js
@@ -7,9 +7,11 @@
 export const DEG_TO_RAD = Math.PI / 180;
 const R_EARTH = 6371000;
 const TERMINAL_MATCH_M = 7500;
-// eog stopped recording an overpass for every flare every night on 2025-10-01,
-// so a cloud-free denominator can be a fraction of the window it looks like.
-// below this share of the window, persistence is not a number we have.
+// the denominator is ours now: a night counts as read when a satellite flew and
+// we sampled the sky at the site's overpass hours, so a low share means a
+// platform outage or a stretch the cloud series has not reached yet — not eog's
+// silence. quarters run 0.93–1.00 read, against 0.68 for one still filling, so
+// the threshold sits in that gap. below it, persistence is not a number we have.
 const COVERAGE_MIN = 0.8;
 
 // Fast equirectangular distance — accurate to <0.1% under 1 km and below ~70° lat.
@@ -103,14 +105,19 @@ export function enrichVNFFeatures(features, minRh) {
         const typeCat = [p.type, p.category].filter(Boolean).join(' — ');
         const name = terminal ? terminal.name : typeCat || `Flare #${p.flare_id}`;
 
-        const passes = p.total_dates;
+        const passes = p.profiled_dates;
+        // both restricted to nights we could see, so the ratio is a rate. the
+        // old max() guarded a numerator larger than its denominator, which the
+        // archive can no longer produce; what it left behind was a window
+        // holding no clear night at all reading 0% — never seen is not unlit.
         const detection_count = p.detection_dates;
-        const observations = Math.max(p.clear_dates, detection_count);
-        // null, not 0, where eog recorded too little of the window to divide by:
-        // an unmeasured flare is not an unlit one. the card renders it as '—'
-        // and the persistence layer filter drops it rather than ranking it.
-        const persistence = p.coverage < COVERAGE_MIN ? null
-            : observations > 0 ? detection_count / observations : 0;
+        const observations = p.clear_dates;
+        // null, not 0, where we read too little of the window to divide by, or
+        // never caught the site under clear sky: an unmeasured flare is not an
+        // unlit one. the card renders it as '—' and the persistence layer
+        // filter drops it rather than ranking it.
+        const persistence = p.coverage < COVERAGE_MIN || observations === 0
+            ? null : detection_count / observations;
 
         result.push({
             type: 'Feature',

--- a/web/clustering.js
+++ b/web/clustering.js
@@ -8,10 +8,11 @@ export const DEG_TO_RAD = Math.PI / 180;
 const R_EARTH = 6371000;
 const TERMINAL_MATCH_M = 7500;
 // the denominator is ours now: a night counts as read when a satellite flew and
-// we sampled the sky at the site's overpass hours, so a low share means a
-// platform outage or a stretch the cloud series has not reached yet — not eog's
-// silence. quarters run 0.93–1.00 read, against 0.68 for one still filling, so
-// the threshold sits in that gap. below it, persistence is not a number we have.
+// we sampled the sky at the site's overpass hours, so a low share means one
+// platform was grounded over this site — not eog's silence, and no longer the
+// calendar running past the cloud series, which now ends where it does. it is a
+// per-site gate: whole quarters average 0.86–1.00 read, and what falls below is
+// the sites under an outage. below it, persistence is not a number we have.
 const COVERAGE_MIN = 0.8;
 
 // Fast equirectangular distance — accurate to <0.1% under 1 km and below ~70° lat.

--- a/web/config.js
+++ b/web/config.js
@@ -78,7 +78,11 @@ async function refreshVNF() {
     try {
         const fc = await queryVNF(viewportBbox(CTX.map), range.startDate, range.endDate);
         _vnfRaw = fc.features;
-        if (isVnf()) updateVNFSource();
+        // an open card holds the previous window's aggregates, so reconcile it
+        // against the re-query the way the slider path does — otherwise a card
+        // keeps a persistence for quarters that are no longer selected, and the
+        // '—' a window with no clear night should show never appears
+        if (isVnf()) { updateVNFSource(); reselectCurrentFeature(); }
     } catch (err) { console.error('VNF query error:', err); }
 }
 

--- a/web/vnf.js
+++ b/web/vnf.js
@@ -80,8 +80,8 @@ function siteFeatures(rows, { detectedOnly = false } = {}) {
                 ...p, lat, lon,
                 // share of the window's nights we read the sky for, over the
                 // exact night count (`days`), not a 91-night approximation.
-                // low means a platform outage or a stretch the cloud series
-                // has not reached — see data-desk/docs/archive/vnf.md
+                // low means a platform was grounded over this site — see
+                // data-desk/docs/archive/vnf.md
                 coverage: p.total_dates ? p.profiled_dates / p.total_dates : 0,
                 // rh_sum spans every detection, cloudy nights included, so its
                 // mean divides by detection_any — not the clear-night count
@@ -121,8 +121,9 @@ export async function queryVNFFlare(flareId, startDate, endDate) {
 /**
  * Daily detection history for one flare (card open) — the only reader of the
  * big daily parquet. That parquet now carries a row for every flare on every
- * night since 2012-03, lit or not, so the detected filter is what keeps this
- * read small. Full history; the card filters to the quarter window.
+ * night from 2012-03 to wherever the cloud series ends, lit or not, so the
+ * detected filter is what keeps this read small. Full history; the card filters
+ * to the quarter window.
  */
 export async function fetchVNFDetections(flareId) {
     const f = (await flareIndex()).get(Number(flareId));

--- a/web/vnf.js
+++ b/web/vnf.js
@@ -20,11 +20,7 @@ export function isReady() { return _ready; }
 
 const sibling = f => _url.replace(/[^/]*$/, f);
 const COLS = ['flare_id', 'lat', 'lon', 'quarter', 'days', 'profiled_days', 'clear_days',
-              'detected_days', 'rh_sum', 'rh_max', 'type', 'category', 'country'];
-// nights in a quarter, near enough. a flare's profiled_days over this is the
-// share of the window eog actually recorded an overpass for, and persistence
-// divides by a cloud-free count that only means something when it is high.
-const QUARTER_NIGHTS = 91;
+              'detected_days', 'detected_any_days', 'rh_sum', 'rh_max', 'type', 'category', 'country'];
 
 /**
  * Initialize VNF: open the quarterly rollup (remote: footer bytes only) so
@@ -59,18 +55,21 @@ function siteFeatures(rows, { detectedOnly = false } = {}) {
             flare_id: Number(r.flare_id), lat: Number(r.lat), lon: Number(r.lon),
             type: '', category: '', country: '',
             total_dates: 0, profiled_dates: 0, clear_dates: 0, detection_dates: 0,
-            rh_sum: 0, max_rh: 0, quarters: new Set(),
+            detection_any: 0, rh_sum: 0, max_rh: 0, quarters: new Set(),
         });
         s.quarters.add(String(r.quarter));
         s.total_dates += Number(r.days);
         s.profiled_dates += Number(r.profiled_days);
         s.clear_dates += Number(r.clear_days);
         s.detection_dates += Number(r.detected_days);
+        s.detection_any += Number(r.detected_any_days);
         s.rh_sum += Number(r.rh_sum);
         s.max_rh = Math.max(s.max_rh, Number(r.rh_max));
         for (const k of ['type', 'category', 'country']) s[k] ||= r[k] || '';
     }
-    const sites = [...by.values()].filter(s => !detectedOnly || s.detection_dates > 0)
+    // any night the site was seen lit, cloudy ones included — a flare only ever
+    // caught under cloud still burned, and dropping it would be a false negative
+    const sites = [...by.values()].filter(s => !detectedOnly || s.detection_any > 0)
         .sort((a, b) => b.max_rh - a.max_rh);
     return {
         type: 'FeatureCollection',
@@ -79,13 +78,14 @@ function siteFeatures(rows, { detectedOnly = false } = {}) {
             geometry: { type: 'Point', coordinates: [lon, lat] },
             properties: {
                 ...p, lat, lon,
-                // share of the selected window eog recorded an overpass for.
-                // since 2025-10-01 it can be low, and a low one makes every
-                // cloud-free denominator below it meaningless — see
-                // data-desk/docs/archive/vnf.md
-                coverage: quarters.size
-                    ? p.profiled_dates / (quarters.size * QUARTER_NIGHTS) : 0,
-                avg_rh: p.detection_dates ? rh_sum / p.detection_dates : 0,
+                // share of the window's nights we read the sky for, over the
+                // exact night count (`days`), not a 91-night approximation.
+                // low means a platform outage or a stretch the cloud series
+                // has not reached — see data-desk/docs/archive/vnf.md
+                coverage: p.total_dates ? p.profiled_dates / p.total_dates : 0,
+                // rh_sum spans every detection, cloudy nights included, so its
+                // mean divides by detection_any — not the clear-night count
+                avg_rh: p.detection_any ? rh_sum / p.detection_any : 0,
                 detections: [],
             },
         })),
@@ -120,7 +120,9 @@ export async function queryVNFFlare(flareId, startDate, endDate) {
 
 /**
  * Daily detection history for one flare (card open) — the only reader of the
- * big daily parquet. Full history; the card filters to the quarter window.
+ * big daily parquet. That parquet now carries a row for every flare on every
+ * night since 2012-03, lit or not, so the detected filter is what keeps this
+ * read small. Full history; the card filters to the quarter window.
  */
 export async function fetchVNFDetections(flareId) {
     const f = (await flareIndex()).get(Number(flareId));
@@ -137,8 +139,8 @@ export async function availableQuartersVNF(bbox, startDate, endDate) {
     if (!_ready) return new Set();
     const [west, south, east, north] = bbox;
     const rows = await read(sibling('quarters.parquet'),
-        { columns: ['lat', 'lon', 'quarter', 'detected_days'],
+        { columns: ['lat', 'lon', 'quarter', 'detected_any_days'],
           where: { lat: [south, north], lon: [west, east],
-                   quarter: [startDate, endDate], detected_days: [1, null] } });
+                   quarter: [startDate, endDate], detected_any_days: [1, null] } });
     return new Set(rows.map(r => quarterOf(r.quarter)));
 }


### PR DESCRIPTION
Follows the rebuilt VNF archive, where the denominator is ours: every flare-night
is a row, and whether we could see the site is ERA5 total cloud cover sampled at
its real VIIRS overpass hours. The calendar now **ends where the cloud series
ends** — 2026-07-21, not today — so the trailing nights that used to be generated
past ERA5 and marked `clear IS NULL`, indistinguishable from a night nobody flew,
are gone.

## What changed

- **coverage** is `profiled_dates / total_dates` — the exact night count in the
  selected quarters (`days`), not `quarters × 91`. The old approximation read
  above 1.0 for 92-night quarters and 0.20 for the quarter in progress.
- **COVERAGE_MIN stays 0.8**, now against a denominator that means something —
  and it is a **per-site** gate rather than a per-quarter one. Whole quarters
  average 0.86–1.00 read; what falls below the threshold are the flares a
  grounded platform left unread. Suomi NPP published no fits worldwide on
  2026-06-01–03 and on nine consecutive nights, 2026-07-11–19, while NOAA-20
  flew — and one platform does not reach every site every night.
- **observations is `clear_dates`**, not `max(clear_dates, detection_count)`.
  `detected_days` is already restricted to clear nights, so the max can no longer
  fire from the archive side (0 of 303,405 flare-quarters).
- **persistence is null where `clear_dates` is 0.** That is what the max was
  actually doing lately: 500 flare-quarters hold no clear night at all, and they
  were reading 0% persistence — never seen reported as never lit.
- **avg_rh divides by `detected_any_days`.** `rh_sum` spans every detection,
  cloudy nights included, so the clear-only count was the wrong denominator.
- **A flare caught only under cloud counts as present** on the map and in the
  quarter dots (`detected_any_days > 0`), instead of vanishing.
- **Card labels**: `Detections (clear)` and `Nights read` (was `Passes`, which
  now would have shown every night in the window, flown or not). S2 labels
  unchanged.
- **An open card now reconciles against the viewport re-query.** The quarter
  picker re-rendered the card from the properties captured when it opened, so a
  card kept a persistence for quarters that were no longer selected and the '—'
  this PR introduces was unreachable from the card. `refreshVNF` calls
  `reselectCurrentFeature`, as the slider path already did.
- `fetchVNFDetections` reads `flare_id, lat, lon, date, detected, rh_mw` — none
  of the removed columns (`n_passes, type, category, country`). No fix needed.

## Figures that move

Both columns are measured on the same rebuilt archive, over the rollup's whole
four-year window (2023 Q1 – 2026 Q3, 20,227 flares, 303,405 flare-quarters);
"old" is `main`'s arithmetic, "new" is this branch's.

| | old | new |
|---|---|---|
| flares past the 3 MW intensity gate | 3,485 | 2,112 |
| mean avg_rh across mapped flares | 3.08 MW | 1.99 MW |
| flare-quarters with no clear night, persistence shown | 500 at 0% | 500 at '—' |
| flares seen lit only under cloud, on the map | 0 | 338 |
| coverage of the whole four-year window (mean) | 0.922 | 0.969 |
| coverage of the quarter in progress (mean) | 0.198 | 0.857 |
| flares the gate suppresses, whole window | 0 | 0 |
| flares the gate suppresses, quarter in progress | all 20,227 | 289 of 6,982 mapped |

The last row is the substantive change since the previous revision of this
branch. The quarter in progress no longer greys out wholesale — the phantom
nights that depressed its coverage are gone, and it reads 0.857, above the
threshold. The gate now fires in exactly three quarters of the fifteen, and
per site within them: 708 of 11,884 mapped flares in 2024 Q2, 644 of 11,765 in
2024 Q3, and 289 of 6,982 in the quarter in progress. That is the platform
outages, which is what it is for.

## ETL / consumption

Nothing in the ETL changes; this is the consumption side catching up with
`views/vnf/quarters.parquet`'s `detected_any_days` column and with
`profiled_days` meaning "a satellite flew and we read the sky" rather than "EOG
wrote us a row".

**This branch requires the rebuilt rollup.** It reads `profiled_days` and
`detected_any_days`; against a `quarters.parquet` without them, VNF mode renders
nothing.

## Verified

Headless Chrome against a local server on the rebuilt parquet. Flare 4809
(Libya) reads 529 clear detections / 530 cloud-free / 562 nights read over
2025-01-01→2026-07-21, matching the archive exactly, with 557 dates listed and
21 Jul 2026 at the head. Over the northern Gulf (47.5°E 29.5°N, z7) the
persistence slider renders 218/176/139/23 features at 0%/25%/50%/95%. Selecting
the quarter in progress alone leaves 150 features, of which 2 are nulled by the
coverage gate and dropped by the layer filter — where before the rebuild every
site in the viewport was. Flare 1033 (Ecuador), which has no clear night in that
quarter, reads `Persistence —`, `Nights read 21`, `Cloud-free (0%) 0`. Console
is clean apart from aborted basemap tile requests. 68/68 tests pass. S2 mode
unaffected.
