### PR TITLE
s2: don't let a missing persistence hide the whole archive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,15 @@ viewport overlaps** — each tile's parquet is loaded once, lazily, and cached;
 viewports are served from those cached tiles (bbox + date-overlap filter), so a
 far-out or uncovered viewport fetches nothing. `archiveFeature` maps a row straight
 to the Feature shape `crossDateCluster` emits, so the avg-B12 slider gates
-client-side but the server-side clustering is not re-run. The in-browser COG detection worker (`detect-worker.js`, the "Detect"
+client-side but the server-side clustering is not re-run. The cluster view's
+`persistence` column is **NULL for all but 8 of the 9,603 published clusters**
+(`s2e cluster` reads its clear-sky denominator from `ops/clouds`, and evidently
+does not find it), so archive rows carry no persistence and no observation count:
+the card reads '—' for both, and the Minimum-persistence gate coalesces a missing
+persistence to *pass* in S2 mode. VNF keeps the opposite branch — there a null is
+a finding (no clear night) and the flare is dropped. Do not "simplify" the two
+branches back into one: coalescing to 0 in S2 mode hides the entire archive
+everywhere except the Qatar clusters. The in-browser COG detection worker (`detect-worker.js`, the "Detect"
 button) is the fallback for areas not yet archived: it runs the s2e rust core
 compiled to wasm (`web/s2/wasm/`), the SAME binary methodology as the server-side
 archive — there is no JS detector port (it drifted from the core and was removed).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,26 +48,34 @@ far-out or uncovered viewport fetches nothing. `archiveFeature` maps a row strai
 to the Feature shape `crossDateCluster` emits, so the avg-B12 slider gates
 client-side but the server-side clustering is not re-run.
 
-**Known upstream regression (2026-07-28): the archive's `persistence` and
-`total_score` are wrong.** `persistence` is NULL and `persistence_score` is 0 for
-9,595 of the 9,603 published clusters, so `total_score` loses its
-`0.40·persistence_score` term while keeping the glint penalty — the archive's mean
-total score is −0.126. Do not rank on the published score until this is rebuilt.
-The mechanism is an asymmetry in `s2e views`: `views/detections/` is partitioned
-by MGRS tile so runs accumulate, but `ops/clouds/data.parquet` is a **single flat
-object rebuilt from whatever is in `observations/` at that moment**. A small run
-(three GEM terminal AOIs, four scenes each) rewrote it on 2026-07-28 with a
-UK-only mask, and `s2e cluster` then reclustered all 112 accumulated detection
-tiles against that remnant — every cluster whose ~100 m cell had no mask row was
-left unmeasured. It cannot simply be re-derived: the global LNG runs' raw
-`observations/**/clouds-*.geojson` are no longer in the bucket. See PR #58.
+**Persistence history (resolved 2026-07-31).** For a period the cluster view
+carried `persistence` NULL and `persistence_score` 0 for 9,595 of its 9,603
+clusters, so `total_score` lost its `0.40·persistence_score` term while keeping
+the glint penalty and the archive's mean score was −0.126. The cause was not a
+deletion: 125 of the 126 detection tiles arrived in a single bulk parquet import
+(2026-07-18) with no canonical records and **no cloud masks**, so the clear-sky
+denominator was never computed for them rather than lost. Compounding it, the
+detector ran `--source cdse-l1c` while its cloud mask reads SCL, which only L2A
+carries — so flare runs wrote empty cloud records regardless.
 
-Because of that, archive rows carry no persistence and no observation count: the
-card reads '—' for both, and the Minimum-persistence gate treats a missing
-persistence as *unrated* (it passes) in S2 mode. VNF keeps the opposite branch —
-there a null is a finding (no clear night) and the flare is dropped. Do not
-"simplify" the two branches back into one: coalescing to 0 in S2 mode sinks the
-whole archive below the slider's 25% default. The in-browser COG detection worker (`detect-worker.js`, the "Detect"
+Both are fixed: `s2e` v0.2.0 resolves SCL from the L2A twin of each acquisition
+whatever `--source` asks for, and a full coverage scan (139,478 scenes, archived
+at `ops/s2e-coverage/`) rebuilt the view on 2026-07-31 — all 9,603 clusters now
+carry a measured persistence. Re-deriving it costs ~20 s via
+`s2e cluster --coverage-scan <dir> --coverage-reuse`.
+
+One consequence to keep in mind: real persistence is low (median ~0.018), so the
+`0.40·persistence_score` term is small even when correct, and the UI's 25%
+default gate passes only ~158 of 9,603 clusters.
+
+A row that still lacks a persistence — none do today, but that is the state the
+above describes — carries no observation count either, so the card reads '—' for
+both rather than passing off `date_count` as the nights we could have seen, and
+the Minimum-persistence gate treats it as *unrated* (it passes) in S2 mode. VNF
+keeps the opposite branch: there a null is a finding (no clear night in the
+window) and the flare is dropped rather than ranked. Do not "simplify" the two
+branches back into one — coalescing to 0 in S2 mode is what sank the whole
+archive below the slider's 25% default. The in-browser COG detection worker (`detect-worker.js`, the "Detect"
 button) is the fallback for areas not yet archived: it runs the s2e rust core
 compiled to wasm (`web/s2/wasm/`), the SAME binary methodology as the server-side
 archive — there is no JS detector port (it drifted from the core and was removed).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,15 +46,28 @@ viewport overlaps** — each tile's parquet is loaded once, lazily, and cached;
 viewports are served from those cached tiles (bbox + date-overlap filter), so a
 far-out or uncovered viewport fetches nothing. `archiveFeature` maps a row straight
 to the Feature shape `crossDateCluster` emits, so the avg-B12 slider gates
-client-side but the server-side clustering is not re-run. The cluster view's
-`persistence` column is **NULL for all but 8 of the 9,603 published clusters**
-(`s2e cluster` reads its clear-sky denominator from `ops/clouds`, and evidently
-does not find it), so archive rows carry no persistence and no observation count:
-the card reads '—' for both, and the Minimum-persistence gate coalesces a missing
-persistence to *pass* in S2 mode. VNF keeps the opposite branch — there a null is
-a finding (no clear night) and the flare is dropped. Do not "simplify" the two
-branches back into one: coalescing to 0 in S2 mode hides the entire archive
-everywhere except the Qatar clusters. The in-browser COG detection worker (`detect-worker.js`, the "Detect"
+client-side but the server-side clustering is not re-run.
+
+**Known upstream regression (2026-07-28): the archive's `persistence` and
+`total_score` are wrong.** `persistence` is NULL and `persistence_score` is 0 for
+9,595 of the 9,603 published clusters, so `total_score` loses its
+`0.40·persistence_score` term while keeping the glint penalty — the archive's mean
+total score is −0.126. Do not rank on the published score until this is rebuilt.
+The mechanism is an asymmetry in `s2e views`: `views/detections/` is partitioned
+by MGRS tile so runs accumulate, but `ops/clouds/data.parquet` is a **single flat
+object rebuilt from whatever is in `observations/` at that moment**. A small run
+(three GEM terminal AOIs, four scenes each) rewrote it on 2026-07-28 with a
+UK-only mask, and `s2e cluster` then reclustered all 112 accumulated detection
+tiles against that remnant — every cluster whose ~100 m cell had no mask row was
+left unmeasured. It cannot simply be re-derived: the global LNG runs' raw
+`observations/**/clouds-*.geojson` are no longer in the bucket. See PR #58.
+
+Because of that, archive rows carry no persistence and no observation count: the
+card reads '—' for both, and the Minimum-persistence gate treats a missing
+persistence as *unrated* (it passes) in S2 mode. VNF keeps the opposite branch —
+there a null is a finding (no clear night) and the flare is dropped. Do not
+"simplify" the two branches back into one: coalescing to 0 in S2 mode sinks the
+whole archive below the slider's 25% default. The in-browser COG detection worker (`detect-worker.js`, the "Detect"
 button) is the fallback for areas not yet archived: it runs the s2e rust core
 compiled to wasm (`web/s2/wasm/`), the SAME binary methodology as the server-side
 archive — there is no JS detector port (it drifted from the core and was removed).

--- a/web/clustering.js
+++ b/web/clustering.js
@@ -67,12 +67,15 @@ export function findNearestTerminal(lat, lon) {
 // shape crossDateCluster emits, so rendering/detail/CSV are unchanged. The view is
 // pre-clustered server-side, so the avg-B12 slider gates these rows client-side and
 // the merge-distance/score controls don't re-run. The view carries no cloud counts,
-// only the published persistence, so we report the cloud-free observation count
-// (detections / persistence) and leave passes null — there is no total-pass figure
-// to compute a meaningful cloud-free fraction from.
+// only the published persistence, so we back the cloud-free observation count out of
+// it (detections / persistence) and leave passes null — there is no total-pass figure
+// to compute a meaningful cloud-free fraction from. Where the view publishes no
+// persistence — which is nearly everywhere — there is no denominator to back out
+// either, so observations stays null and the card reads '—' rather than passing off
+// date_count, the detection dates themselves, as the nights we could have seen.
 export function archiveFeature(c) {
     const terminal = findNearestTerminal(c.lat, c.lon);
-    const observations = c.persistence ? Math.round(c.detection_count / c.persistence) : c.date_count;
+    const observations = c.persistence ? Math.round(c.detection_count / c.persistence) : null;
     return {
         type: 'Feature',
         geometry: { type: 'Point', coordinates: [c.lon, c.lat] },

--- a/web/clustering.js
+++ b/web/clustering.js
@@ -70,9 +70,9 @@ export function findNearestTerminal(lat, lon) {
 // only the published persistence, so we back the cloud-free observation count out of
 // it (detections / persistence) and leave passes null — there is no total-pass figure
 // to compute a meaningful cloud-free fraction from. Where the view publishes no
-// persistence — which is nearly everywhere — there is no denominator to back out
-// either, so observations stays null and the card reads '—' rather than passing off
-// date_count, the detection dates themselves, as the nights we could have seen.
+// persistence there is no denominator to back out either, so observations stays
+// null and the card reads '—' rather than passing off date_count, the detection
+// dates themselves, as the nights we could have seen.
 export function archiveFeature(c) {
     const terminal = findNearestTerminal(c.lat, c.lon);
     const observations = c.persistence ? Math.round(c.detection_count / c.persistence) : null;

--- a/web/config.js
+++ b/web/config.js
@@ -57,7 +57,16 @@ let CTX;                                    // cartograph ctx (set in sources)
 let readyResolve;
 const whenReady = new Promise(r => readyResolve = r);
 
-const persistenceFilter = v => ['>=', ['coalesce', ['get', 'persistence'], 0], v];
+// a minimum gate can only exclude what was measured, and the two modes mean
+// different things by a null persistence. vnf's null is a finding — no clear
+// night in the window, so the flare is dropped rather than ranked. the s2
+// cluster view publishes no denominator at all (9,595 of 9,603 archived
+// clusters carry persistence NULL), so scoring those as 0 hid the entire
+// archive everywhere except the handful of qatar clusters that do have one.
+const persistenceFilter = v =>
+    ['>=', ['coalesce', ['get', 'persistence'], isVnf() ? 0 : 1], v];
+const applyPersistenceFilter = () =>
+    CTX.map.setFilter('detections', persistenceFilter(PERSISTENCE_MIN));
 const setDetections = features =>
     CTX.map.getSource('detections')?.setData({ type: 'FeatureCollection', features });
 
@@ -250,6 +259,7 @@ function switchMode(m) {
 
     updateS2Controls();
     CTX.map.setLayoutProperty('detections', 'icon-image', markIconExpr(cfg));
+    applyPersistenceFilter();   // the null branch is mode-dependent
 }
 
 // ---------------------------------------------------------------------------
@@ -380,7 +390,7 @@ mount({
         {
             key: 'persistence', label: 'Minimum persistence',
             min: 0, max: 1, step: 0.05, value: 0.25, format: v => `${Math.round(v * 100)}%`,
-            onInput: v => { PERSISTENCE_MIN = v; CTX.map.setFilter('detections', persistenceFilter(v)); },
+            onInput: v => { PERSISTENCE_MIN = v; applyPersistenceFilter(); },
         },
     ],
 

--- a/web/config.js
+++ b/web/config.js
@@ -60,12 +60,14 @@ const whenReady = new Promise(r => readyResolve = r);
 // a minimum gate can only exclude what was measured, and the two modes mean
 // different things by a null persistence. vnf's null is a finding — no clear
 // night in the window, so the flare is dropped rather than ranked. s2's is a
-// gap: 9,595 of the 9,603 published clusters carry persistence NULL because
-// the archive's cloud mask was clobbered (see CLAUDE.md), and scoring an
-// unmeasured site 0 sank all of them below the 25% default at once. treat the
-// gap as unrated rather than as a zero — the slider still gates every cluster
-// that has a real persistence, so this branch retires itself once the mask is
-// rebuilt.
+// gap in the archive, so treat it as unrated rather than as a zero.
+//
+// this branch is idle today: the cluster view has carried a real persistence for
+// every cluster since the 2026-07-31 coverage rebuild. it is here because for a
+// while it did not — the detections were bulk-imported without the cloud masks
+// that make the denominator, so 9,595 of 9,603 clusters had none — and scoring
+// an unmeasured site 0 put every one of them under the 25% default at once. the
+// map went blank everywhere it was covered and nothing said why.
 const persistenceFilter = v =>
     ['>=', ['coalesce', ['get', 'persistence'], isVnf() ? 0 : 1], v];
 const applyPersistenceFilter = () =>

--- a/web/config.js
+++ b/web/config.js
@@ -59,10 +59,13 @@ const whenReady = new Promise(r => readyResolve = r);
 
 // a minimum gate can only exclude what was measured, and the two modes mean
 // different things by a null persistence. vnf's null is a finding — no clear
-// night in the window, so the flare is dropped rather than ranked. the s2
-// cluster view publishes no denominator at all (9,595 of 9,603 archived
-// clusters carry persistence NULL), so scoring those as 0 hid the entire
-// archive everywhere except the handful of qatar clusters that do have one.
+// night in the window, so the flare is dropped rather than ranked. s2's is a
+// gap: 9,595 of the 9,603 published clusters carry persistence NULL because
+// the archive's cloud mask was clobbered (see CLAUDE.md), and scoring an
+// unmeasured site 0 sank all of them below the 25% default at once. treat the
+// gap as unrated rather than as a zero — the slider still gates every cluster
+// that has a real persistence, so this branch retires itself once the mask is
+// rebuilt.
 const persistenceFilter = v =>
     ['>=', ['coalesce', ['get', 'persistence'], isVnf() ? 0 : 1], v];
 const applyPersistenceFilter = () =>


### PR DESCRIPTION
## What this is now

**The regression this was written for is fixed.** The 2026-07-31 coverage rebuild gave all 9,603 clusters a measured persistence, so the S2 branch here never fires against today's archive. It is defence-in-depth, and worth keeping for exactly the reason it was written.

## What went wrong

The `detections` layer gates on the Minimum-persistence slider:

```js
['>=', ['coalesce', ['get', 'persistence'], 0], v]   // v defaults to 0.25
```

A null persistence coalesced to `0`, so it failed the 25% default and never drew. For a period 9,595 of 9,603 clusters had no persistence — so the map was blank at every covered site except Ras Laffan, which happens to be the default viewport, and nothing said why. It looked like a rendering bug; you had to drag the slider to zero to see anything.

The cause was upstream and is worth recording accurately, because my first reading of it was wrong: nothing was deleted. 125 of the 126 detection tiles arrived in a **bulk parquet import** with no canonical records and no cloud masks behind them, so the clear-sky denominator was never computed for those sites rather than destroyed. Separately, the detector ran `--source cdse-l1c` while its cloud mask reads SCL, which only L2A carries — so flare runs wrote empty cloud records regardless. Both are fixed in `s2e` v0.2.0.

## Changes

- **The persistence gate treats an unmeasured cluster as unrated, not as zero** (S2 only). A minimum gate can only exclude what it measured. VNF keeps the opposite branch — there a null is a real finding (no clear night in the window) and dropping the flare is the point of d310d54. Re-applied on mode switch, since the branch depends on the mode.
- **`archiveFeature` no longer passes `date_count` off as the cloud-free observation count.** That is just the detection dates again, and with a quarter subset selected `quarterMetrics` turned it into a fabricated persistence. It reports `null`, so the card reads '—'.
- **CLAUDE.md** records the history and the corrected cause.

## Verification

- `make test` — 68/68.
- Bonny (`#map=12/4.909/6.907`) against the live archive at the time: 0/3 rendered → 3/3.
- S2 → VNF → S2 flips the branch correctly; VNF at Ras Laffan still renders 7 of 13, the rest held back by real persistence values.
- An archive card read `Detections 22 · Persistence — · Passes — · Cloud-free obs. —` instead of inventing the last three.
- Post-rebuild, the live map renders detections at **default** settings (persistence 0.93 / 0.94 / 0.90 / 0.78 at Bonny) with no slider adjustment.

## Note for later

Real persistence is low (median ~0.018), so the 25% default gate now passes only ~158 of 9,603 clusters — honest, but worth deciding whether it is the right landing experience. At 10% it would be 966; at 5%, 1,855.