### PR TITLE
vnf: read the daily series as 64 spatial cells

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,11 +132,20 @@ merging results via LWW-Map CRDT. The CRDT/mesh stack is **loaded lazily**
 sits outside the archive's coverage — a pure-archive session never fetches it. The
 archive base is set via `<meta name="s2-archive">` in index.html.
 
-**VNF mode:** hyparquet reads a pre-built Parquet file containing per-flare
-daily observations from EOG profile CSVs. In production it lives in the shared
-datadesk CloudFerro archive at `views/vnf/data.parquet` (`<meta name="vnf-url">`); dev
-falls back to a local `web/vnf.parquet`. Each row has `clear`/`detected` booleans
-for real cloud-free persistence metrics.
+**VNF mode:** hyparquet reads pre-built Parquet holding per-flare daily
+observations from EOG profile CSVs. In production it lives in the shared
+datadesk CloudFerro archive under the prefix `views/vnf/`
+(`<meta name="vnf-url">` — the prefix, not a file); dev falls back to a build
+laid out the same way under `web/`. Each row has `clear`/`detected` booleans for
+real cloud-free persistence metrics.
+
+The daily series is **64 spatial cells**, `views/vnf/data/cell=<n>/data.parquet`,
+sorted by `(flare_id, date)` inside each one, so a card open range-reads one row
+group of one ~9 MB object behind a 114 KB footer — 6 requests and 539 KB against
+the 69 requests and 3.4 MB the single 539 MB file cost. `flares.parquet` carries
+each flare's `cell`, so an id resolves to its object with no bucket listing, and
+a bbox reader filters that same file to the cells it must open. See
+`~/Tools/etl/vnf/REBUILD.md`.
 
 ## Commands
 
@@ -305,13 +314,16 @@ flare × night calendar → EOG profile CSVs   → detections (Planck fits)
                        → terminals.geojson (6 km) → flare index (type, category, country)
 ```
 
-Daily parquet (`views/vnf/data.parquet`): `flare_id, lat, lon, date, clear,
-detected, tcc, rh_mw, temp_k, flow_mcm, looks, profiled`. `clear` is BOOLEAN and
-NULL means unobserved — never conflate it with cloudy. `profiled` survives from
-the old build and still gates the same way, but it now says a satellite flew and
-we read the sky rather than that EOG chose to write a row; 98.8% of flare-nights
-across the archive are observed. `type, category, country` moved out to
-`views/vnf/flares.parquet` and `n_passes` is gone. Coordinates are stable
+Daily parquet (`views/vnf/data/cell=<n>/data.parquet`, 64 cells): `flare_id,
+date, clear, detected, tcc, rh_mw, temp_k, flow_mcm, looks, profiled`. `clear` is
+BOOLEAN and NULL means unobserved — never conflate it with cloudy. `profiled`
+survives from the old build and still gates the same way, but it now says a
+satellite flew and we read the sky rather than that EOG chose to write a row;
+98.8% of flare-nights across the archive are observed. `type, category, country`
+moved out to `views/vnf/flares.parquet` and `n_passes` is gone. **`lat` and `lon`
+moved there too** (2026-07-30) — a per-flare constant belongs in the index, and
+they only ever rode along so a remote reader could prune spatially on a file
+sorted by position. Join `flares.parquet` for coordinates; they are stable
 per-flare averages (from profile passes), not per-pass positions. `flow_mcm` carries
 EOG's own per-pass `Flow_Rate` (daily-averaged like `rh_mw`; 0 on
 nightly-backfilled rows — the ez CSVs have no flow) but is NOT displayed:

--- a/web/config.js
+++ b/web/config.js
@@ -23,11 +23,13 @@ if (/^#vnf\/\d+$/.test(location.hash))
 // build config (index.html meta tags) + mode state ('s2' or 'vnf')
 // ---------------------------------------------------------------------------
 
-// vnf parquet lives in the central datadesk store (CloudFerro) at a stable key
-// (vnf/data.parquet) — public-read, hyparquet range-reads it remotely. set via
-// <meta name="vnf-url">; localhost (or an unset url) falls back to a local build.
+// vnf lives in the central datadesk archive (CloudFerro) under a stable prefix
+// (views/vnf/) — public-read, hyparquet range-reads it remotely. the prefix, not
+// a file: the rollup and flare index sit in it and the daily series is 64 cells
+// below it. set via <meta name="vnf-url">; localhost (or an unset url) falls
+// back to a build laid out the same way under web/.
 const VNF_URL = document.querySelector('meta[name="vnf-url"]')?.content || '';
-const vnfUrl = () => (location.hostname === 'localhost' || !VNF_URL) ? 'vnf.parquet' : VNF_URL;
+const vnfUrl = () => (location.hostname === 'localhost' || !VNF_URL) ? '' : VNF_URL;
 
 // s2 mode reads the precomputed cluster view straight from the CloudFerro parquet
 // archive (`data-desk/infra/archive.sh publish`); the in-browser COG worker ("Detect")

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="signaling-url" content="wss://burnoff-signaling.louis-6bf.workers.dev">
-    <meta name="vnf-url" content="https://s3.WAW3-2.cloudferro.com/data-desk-archive/views/vnf/data.parquet">
+    <meta name="vnf-url" content="https://s3.WAW3-2.cloudferro.com/data-desk-archive/views/vnf/">
     <!-- s2 mode reads the precomputed cluster view straight from the CloudFerro parquet
          archive (`data-desk/infra/archive.sh publish`). empty = client-side detection only. -->
     <meta name="s2-archive" content="https://s3.WAW3-2.cloudferro.com/data-desk-archive">

--- a/web/vnf.js
+++ b/web/vnf.js
@@ -3,46 +3,51 @@
 // then only the row groups a query's bbox/date filter touches via row-group
 // stats). Zero npm dependencies.
 //
-// Two tiers, both hilbert-ordered over (lon, lat) so bbox reads prune row
-// groups spatially: the viewport reads a small flare x quarter rollup
-// (quarters.parquet, windowed to the UI's quarter grid); the big daily
-// parquet is read only per flare, on card open, via fetchVNFDetections — so
-// its multi-MB footer loads lazily behind the first card. flares.parquet
-// (flare_id -> lat/lon) resolves ids to positions so per-flare reads can
-// filter spatially too.
+// Two tiers. The viewport reads a small flare x quarter rollup
+// (quarters.parquet, hilbert-ordered over (lon, lat) so a bbox prunes row
+// groups spatially, windowed to the UI's quarter grid). The daily series is
+// read only per flare, on card open, via fetchVNFDetections.
+//
+// That daily series is 64 spatial cells, not one file, and inside a cell the
+// rows are sorted by (flare_id, date) — so a card range-reads one row group of
+// one ~9 MB object behind a 114 KB footer. It used to be one 539 MB file
+// hilbert-ordered end to end, where a flare's nights were scattered over a
+// dozen row groups and a card decoded 559,574 rows to show 958 detections.
+// flares.parquet carries the cell each flare lives in, so an id resolves to its
+// object without listing the bucket.
 
 import { read, meta } from './vendor/cartograph/data.js';
 import { quarterOf } from './vendor/cartograph/util.js';
 
-let _url = null, _initPromise = null, _ready = false;
+let _base = null, _initPromise = null, _ready = false;
 
 export function isReady() { return _ready; }
 
-const sibling = f => _url.replace(/[^/]*$/, f);
+const url = f => _base + f;
 const COLS = ['flare_id', 'lat', 'lon', 'quarter', 'days', 'profiled_days', 'clear_days',
               'detected_days', 'detected_any_days', 'rh_sum', 'rh_max', 'type', 'category', 'country'];
 
 /**
  * Initialize VNF: open the quarterly rollup (remote: footer bytes only) so
  * viewport queries can range-read row groups.
- * @param {string} url - URL or local path to the daily parquet (the rollup
- *   and flare index are resolved as siblings)
+ * @param {string} base - URL or local path prefix of the vnf view, ending in a
+ *   slash: the rollup, the flare index and data/cell=N/ hang off it
  */
-export function initVNF(url) {
-    _url = url;
-    return _initPromise ??= meta(sibling('quarters.parquet')).then(() => { _ready = true; });
+export function initVNF(base) {
+    _base = base;
+    return _initPromise ??= meta(url('quarters.parquet')).then(() => { _ready = true; });
 }
 
-/** Reset state so initVNF can be called again with a different URL. */
+/** Reset state so initVNF can be called again with a different base. */
 export function resetVNF() {
     _initPromise = null;
     _ready = false;
-    _url = null;
+    _base = null;
     _flares = null;
 }
 
 let _flares = null;
-const flareIndex = () => _flares ??= read(sibling('flares.parquet'))
+const flareIndex = () => _flares ??= read(url('flares.parquet'))
     .then(rows => new Map(rows.map(r => [Number(r.flare_id), r])));
 
 // Rollup rows grouped to one feature per flare with summed quarter aggregates
@@ -99,7 +104,7 @@ function siteFeatures(rows, { detectedOnly = false } = {}) {
 export async function queryVNF(bbox, startDate, endDate) {
     if (!_ready) throw new Error('VNF not initialized');
     const [west, south, east, north] = bbox;
-    const rows = await read(sibling('quarters.parquet'), { columns: COLS,
+    const rows = await read(url('quarters.parquet'), { columns: COLS,
         where: { lat: [south, north], lon: [west, east], quarter: [startDate, endDate] } });
     return siteFeatures(rows, { detectedOnly: true });
 }
@@ -112,7 +117,7 @@ export async function queryVNFFlare(flareId, startDate, endDate) {
     if (!_ready) throw new Error('VNF not initialized');
     const f = (await flareIndex()).get(Number(flareId));
     if (!f) return { type: 'FeatureCollection', features: [] };
-    const rows = await read(sibling('quarters.parquet'), { columns: COLS,
+    const rows = await read(url('quarters.parquet'), { columns: COLS,
         where: { flare_id: [Number(flareId), Number(flareId)], quarter: [startDate, endDate],
                  lat: [f.lat - 0.01, f.lat + 0.01], lon: [f.lon - 0.01, f.lon + 0.01] } });
     return siteFeatures(rows);
@@ -120,17 +125,23 @@ export async function queryVNFFlare(flareId, startDate, endDate) {
 
 /**
  * Daily detection history for one flare (card open) — the only reader of the
- * big daily parquet. That parquet now carries a row for every flare on every
- * night from 2012-03 to wherever the cloud series ends, lit or not, so the
- * detected filter is what keeps this read small. Full history; the card filters
- * to the quarter window.
+ * daily series. It carries a row for every flare on every night from 2012-03 to
+ * wherever the cloud series ends, lit or not, so the detected filter is what
+ * keeps this small. Full history; the card filters to the quarter window.
+ *
+ * The flare's cell is the whole of the addressing: one object, and inside it
+ * the flare_id predicate prunes to a row group off the footer statistics. There
+ * is no lat/lon predicate any more — it was only ever standing in for an index
+ * on a file sorted by position, and the daily rows no longer carry a position.
+ * `detected` has to stay in `columns` as well as `where`: cartograph filters
+ * rows on the values it read, and a column it never read reads as null.
  */
 export async function fetchVNFDetections(flareId) {
     const f = (await flareIndex()).get(Number(flareId));
     if (!f) return [];
-    const rows = await read(_url, { columns: ['flare_id', 'lat', 'lon', 'date', 'detected', 'rh_mw'],
-        where: { flare_id: [Number(flareId), Number(flareId)], detected: [true, true],
-                 lat: [f.lat - 0.01, f.lat + 0.01], lon: [f.lon - 0.01, f.lon + 0.01] } });
+    const rows = await read(url(`data/cell=${Number(f.cell)}/data.parquet`),
+        { columns: ['flare_id', 'date', 'detected', 'rh_mw'],
+          where: { flare_id: [Number(flareId), Number(flareId)], detected: [true, true] } });
     return rows.map(r => ({ date: String(r.date).slice(0, 10), rh_mw: Number(r.rh_mw) || 0 }))
         .sort((a, b) => a.date < b.date ? -1 : 1);
 }
@@ -139,7 +150,7 @@ export async function fetchVNFDetections(flareId) {
 export async function availableQuartersVNF(bbox, startDate, endDate) {
     if (!_ready) return new Set();
     const [west, south, east, north] = bbox;
-    const rows = await read(sibling('quarters.parquet'),
+    const rows = await read(url('quarters.parquet'),
         { columns: ['lat', 'lon', 'quarter', 'detected_any_days'],
           where: { lat: [south, north], lon: [west, east],
                    quarter: [startDate, endDate], detected_any_days: [1, null] } });


### PR DESCRIPTION
Pairs with [data-desk-eco/etl@5099972](https://github.com/data-desk-eco/etl/commit/5099972), already built and published — `views/vnf/data/cell=1…64/data.parquet` are live in the archive.

## Why

`views/vnf/data.parquet` was one 539 MB file Hilbert-ordered end to end. That serves a bbox and nothing else: a flare's nights were scattered across a dozen row groups, so opening a card decoded **559,574 rows to display 958 detections** — about 4.5 s, of which only 0.7 s was network.

## What changed

`<meta name="vnf-url">` now names the `views/vnf/` **prefix** rather than a file. The rollup and flare index sit in it; the daily series hangs below it as `data/cell=<n>/data.parquet`, sorted by `(flare_id, date)` inside each cell. `flares.parquet` carries each flare's `cell`, so an id resolves to one object with no bucket listing.

The lat/lon predicate is gone — it only ever stood in for an index on a file sorted by position, and the daily rows no longer carry a position.

## Measured

Same flare, same 958 detections, both layouts back to back on one network:

| | requests | bytes | rows decoded | wall |
|---|---|---|---|---|
| one Hilbert file | 69 | 3,465 KB | 559,574 | 56.2 s |
| 64 cells | 6 | 539 KB | 10,240 | 5.4 s |

Wall times are inflated ~10× — the link to CloudFerro was at 354 ms RTT during the run against 33 ms earlier the same day. The request and byte counts are the network-independent claim; on a normal link the old path measured 4.5 s.

Verified end to end on `#vnf=4998` against the live archive: correct flare, correct position, detection history rendering with the right RH and MCM values. `make test` — 68/68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)